### PR TITLE
Add gpiod

### DIFF
--- a/src/odin_devices/gpio_bus.py
+++ b/src/odin_devices/gpio_bus.py
@@ -1,0 +1,86 @@
+import gpiod
+
+# TODO can I use with to protect the resources being lost? Pins MUST be released
+
+class GPIO_Bus():
+    DIR_INPUT = gpiod.LINE_REQ_DIR_IN
+    DIR_OUTPUT = gpiod.LINE_REQ_DIR_OUT
+
+    ACTIVE_L = gpiod.Line.ACTIVE_LOW
+    ACTIVE_H = gpiod.Line.ACTIVE_HIGH
+
+    def __init__(self, width, chipno=0, system_offset=0):
+        # Select the specified GPIO chip
+        self._gpio_chip = gpiod.Chip("/dev/gpiochip" +str(chipno))
+
+        # Place the chosen lines into a bulk for offset removal. Not requested until use.
+        self._system_offset = system_offset
+        self._width = width
+        self._master_linebulk = self._gpio_chip.get_lines(range(system_offset, system_offset+width))
+
+        # Set the consumer name
+        self._consumer_name = "odin_gpio_bus"
+
+    def get_consumer_name(self):
+        return self._consumer_name
+
+    def set_consumer_name(self, consumer_name):
+        self._consumer_name = consumer_name
+
+    def get_width(self):
+        return self._width
+
+    def set_width(self, new_width):
+        # Create a new linebulk, since this does not imply ownership.
+
+        # Free pins that would become inaccessible
+        if new_width < width:
+            for i in range(new_width, width):
+                self._master_linebulk.to_list()[i].release()
+
+        self._gpio_chip.get_lines(range(self._system_offset, self._system_offset + new_width))
+
+    def get_pin(self, index, direction, active_l=False, no_request=False):
+        # TODO Check pin is within range, and unrequested
+        # TODO if requested, but by current application, call with no_request and warn
+
+        # Create GPIO_Pin wrapper around master linebulk pin
+        line = self._master_linebulk.to_list()[index]
+        if no_request == False:
+            if active_l:
+                flags = LINE_REQ_FLAG_ACTIVE_LOW
+            else:
+                flags = 0
+            line.request(consumer=self._consumer_name,
+                         type = direction,
+                         flags = flags,
+                         default_val = 0)
+
+        return line
+
+    def get_bulk_pins(self, indexes, direction, active_l=False, no_request=False):
+        # TODO check pin indexes are all in range, and unrequested
+        # TODO if requested, but by current consumer, call with no_request and warn
+
+        # Create GPIO_Bulk_Pins wrapper around master linebulk pin
+        lines = self._master_linebulk.get_lines(indexes)
+        if no_request == False:
+            if active_l:
+                flags = LINE_REQ_FLAG_ACTIVE_LOW
+            else:
+                flags = 0
+            lines.request(consumer=self._consumer_name,
+                         type = direction,
+                         flags = active,
+                         default_val = 0)
+
+        return lines
+
+    def release_all_consumed(self):
+        self._master_linebulk.release()
+
+
+# Example buses
+GPIO_Zynq = GPIO_Bus(12, 0, 54)         # Width will need to match EMIO GPIO width
+GPIO_ZynqMP = GPIO_Bus(12, 0, 78)       # Width will need to match EMIO GPIO width
+

--- a/src/odin_devices/gpio_bus.py
+++ b/src/odin_devices/gpio_bus.py
@@ -117,10 +117,13 @@ class GPIO_Bus():
     Pin Requests
     """
     def _check_pin_avail(self, index, ignore_current=False):
-        self._master_linebulk.to_list()[index].update()
         # Check if the pin is in range
         if index >= self._width:
             raise GPIOException ("GPIO Pin index out of range, bus width: {}".format(self._width))
+        elif index < 0:
+            raise GPIOException ("Gpio Pin index cannot be negative")
+
+        self._master_linebulk.to_list()[index].update()     # Sync line info with kernel
 
         if not ignore_current:
             # Check pin is not already requested for other operations by this user

--- a/src/odin_devices/gpio_bus.py
+++ b/src/odin_devices/gpio_bus.py
@@ -106,7 +106,7 @@ class GPIO_Bus():
 
         # Free pins that would become inaccessible
         if new_width < self._width:
-            for i in range(new_width, width):
+            for i in range(new_width, self._width):
                 self._master_linebulk.to_list()[i].release()
 
         self._master_linebulk = self._gpio_chip.get_lines(range(self._system_offset, self._system_offset + new_width))

--- a/src/odin_devices/gpio_bus.py
+++ b/src/odin_devices/gpio_bus.py
@@ -1,3 +1,26 @@
+"""Wrapper to abstract hardware-specific details and present a simple GPIO bus of gpiod lines
+
+This class enables the definitions of GPIO buses based the libgpiod python bindings. Lines use
+simple indexes with an internal offset (Examples for Zynq and ZynqMP included at EOF).
+
+Lines (pins) returned are gpiod pin instances as created by libgpiod. Therefore refer to the
+documentation for the python bindings originally hosted at https://github.com/brgl/libgpiod, now
+at https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/
+
+General libgpiod pin functions (applicable to objects returned by get_pin()):
+    - get_value()           Returns high or low value read from the pin in INPUT mode
+    - set_value()           Sets the pin high or low in OUTPUT mode
+
+General libgpiod linebulk functions (applicable to objects returned from get_bulk_pins():
+    - get_values()          Returns array of high or low values read from pins in INPUT mode.
+    - set_values()          Sets the pins high or low in OUTPUT mode using an array of values
+
+Additional functions simplifying the registering of events and waiting have been added, including
+asynchronous versions that will call a supplied callback when the event occurs.
+
+Joseph Nobes, Grad Embedded Sys Eng, STFC Detector Systems Software Group
+"""
+
 import logging
 import sys
 logger = logging.getLogger('odin_devices.gpio_bus')
@@ -47,6 +70,12 @@ GPIO Bus Class:
 """
 
 class GPIO_Bus():
+    """
+    A class to represent a set of consecutive GPIO lines by keeping the offset of those lines
+    abstract from the user. Instances should be defined for different devices by specifying the
+    relevant chip number from /dev/gpiochip and the offset of the bus pins in use.
+    """
+
     DIR_INPUT = gpiod.LINE_REQ_DIR_IN
     DIR_OUTPUT = gpiod.LINE_REQ_DIR_OUT
 
@@ -60,6 +89,15 @@ class GPIO_Bus():
     EV_REQ_BOTH_EDGES = gpiod.LINE_REQ_EV_BOTH_EDGES
 
     def __init__(self, width, chipno=0, system_offset=0):
+        """
+        Create a new bus instance for a set of gpiod pins on a specified bus at a specified offset.
+
+        :param width:           The number of concurrent pins to be referenced by this bus
+        :param chipno:          The number of the relevant gpio chip in /dev/gpiochip*
+        :param system_offset:   The offset of this bus from GPIO 0. In the case of Xilinx Zynq this
+                                is due to numbering reserved for MIO lines rather than EMIO.
+        """
+
         # Check width is valid
         if not width > 0:
             raise GPIOException(
@@ -94,17 +132,24 @@ class GPIO_Bus():
     Bus and Consumer Management
     """
     def get_consumer_name(self):
+        """ Return the consumer name that will be used to consume (reserve) gpiod pins. """
         return self._consumer_name
 
     def set_consumer_name(self, consumer_name):
+        """ Set the consumer name that will be used to consume (reserve) gpiod pins. """
         self._consumer_name = consumer_name
 
     def get_width(self):
+        """ Return the width (number of gpiod lines) associated with this bus """
         return self._width
 
     def set_width(self, new_width):
-        # Create a new linebulk, since this does not imply ownership.
+        """
+        Change the width (number of gpiod lines) associated with this bus. If the width is less
+        than the previous width, the lines that would become inaccessible are released.
 
+        :param new_width:   New width to be set
+        """
         # Free pins that would become inaccessible
         if new_width < self._width:
             for i in range(new_width, self._width):
@@ -117,6 +162,18 @@ class GPIO_Bus():
     Pin Requests
     """
     def _check_pin_avail(self, index, ignore_current=False):
+        """
+        Check if a given pin is available to be requested for use by the user. This includes checks
+        for range in the bus, whether the line has already been requested by the current user, and
+        check for whether the line is in use by the kernel or a different user.
+
+        If the pin is not available, an exception will be raised. Otherwise, no action.
+
+        :param index:               Bus index of the line to be checked
+        :param ignore_current:      Set True to return success if the pin is in use, but by the
+                                    current user.
+        """
+
         # Check if the pin is in range
         if index >= self._width:
             raise GPIOException ("GPIO Pin index out of range, bus width: {}".format(self._width))
@@ -135,6 +192,18 @@ class GPIO_Bus():
             raise GPIOException ("This line is already in use by another user or the kernel")
 
     def get_pin(self, index, direction, active_l=False, no_request=False):
+        """
+        Claims the gpiod pin from the system, if available. Return the relevant gpiod pin.
+
+        :param index:               Bus index of the line to be retrieved
+        :param direction:           IO direction of the pin. One of GPIO_Bus.DIR_INPUT/OUTPUT
+        :param active_l:            (optional) If True, pin will be active low when set to 1.
+                                    False by default.
+        :param no_request:          (optional) If True, do not attempt to request use of the pin
+                                    from the system. Might be useful to free it if the index is
+                                    known. False by default.
+        :return:                    Requested gpiod line.
+        """
 
         # check pin is valid and available.
         # If being called with no_request=True, the pin is being returned without request, so
@@ -156,6 +225,22 @@ class GPIO_Bus():
         return line
 
     def get_bulk_pins(self, indexes, direction, active_l=False, no_request=False):
+        """
+        Similar to get_pin but returns a gpiod 'linebulk' instance that refers to several lines at
+        once. These lines' values can be set and read with arrays. It is also iterable. The indexes
+        included in the linebulk do not have to be concurrent, and can be in any order. Read/write
+        arrays will be in this order.
+
+        :param indexs:              Array of bus indexes of the lines to be retrieved
+        :param direction:           IO direction of the pins. One of GPIO_Bus.DIR_INPUT/OUTPUT. All
+                                    pins in the linebulk have the same direction.
+        :param active_l:            (optional) If True, pins will be active low when set to 1.
+                                    False by default.
+        :param no_request:          (optional) If True, do not attempt to request use of the pins
+                                    from the system. Might be useful to free them if the indexes are
+                                    known. False by default.
+        :return:                    gpiod linebulk instance
+        """
 
         # Check pins are valid and available
         # If being called with no_request=True, the pins are being returned without request, so
@@ -179,12 +264,25 @@ class GPIO_Bus():
         return lines
 
     def release_all_consumed(self):
+        """ Release all lines currently consumed by this bus. """
         self._master_linebulk.release()
 
     """
     Synchronous Event Handling:
     """
     def register_pin_event(self, index, event_request_type):
+        """
+        Register an event on a given pin, so that it can be polled on or checked in a non-blocking
+        manner.
+
+        :param index:               Bus index of the line to register the event with
+        :param event_request_type:  Type of event:
+                                        - GPIO_Bus.EV_REQ_FALLING       for falling edge
+                                        - GPIO_BUS.EV_REQ_RISING        for rising edge
+                                        - GPIO_Bus.EV_REQ_BOTH_EDGES    for either edge
+        :return:                    The line on which the event was registered.
+        """
+
         # Check event request is one of those defined at the top
         if event_request_type not in [GPIO_Bus.EV_REQ_RISING,
                 GPIO_Bus.EV_REQ_FALLING,
@@ -205,11 +303,23 @@ class GPIO_Bus():
         return line
 
     def remove_pin_event(self, index):
+        """ Remove the event request from pin with given bus index """
         # Free pin
         line = self.get_pin(index, None, False, True)
         line.release()
 
     def wait_pin_event(self, index, timeout_s=0):
+        """
+        Wait on a pin event to trigger. This can be non-blocking if called without a timeout.
+
+        :param index:               Bus index of the line to wait for an event from
+        :param timeout_s:           Time to wait in seconds before returning if there was no event.
+                                    If unassigned or 0, will return immediately whether event has
+                                    occurred. If set to a negative value, will wait forever (ppoll).
+        :return:                    Returns 0 if no event was found or if timeout was reached.
+                                    Otherwise returns the type of event
+        """
+
         # Directly wraps the gpiod call with a check. Blocking if no timeout is supplied.
         # event description if event occured, False if timeout
 
@@ -232,6 +342,15 @@ class GPIO_Bus():
     Asynchronous Event Callbacks:
     """
     def _event_monitor_task(self, callback_function, index, line):
+        """
+        Task that will execute line event polling in the background.
+
+        :param callback_function:       Function that will be called when an event is detected.
+                                        Arguments will be event type followed by line index.
+        :param index:                   Bus index of the line that is being checked
+        :param line:                    The line instance that is to be checked
+        """
+
         # ThreadPool futures can only be terminated individually by finishing work
         while not index in self._monitor_remove_pending:
             # Check non-blocking so that event monitor removal is polled
@@ -240,7 +359,20 @@ class GPIO_Bus():
                 callback_function(event.type, index)    # Call the user's callback
 
     def register_pin_event_callback(self, index, event_request_type, callback_function):
-        # Callback has 2 arguments, event and index. Event is one of those defined at the top
+        """
+        Register a callback to be associated with a given event for a given pin. The same function
+        can be passed for event callbacks to different lines.
+
+        :param index:               Bus index of the line to wait for an event from
+        :param event_request_type:  Type of event:
+                                        - GPIO_Bus.EV_REQ_FALLING       for falling edge
+                                        - GPIO_BUS.EV_REQ_RISING        for rising edge
+                                        - GPIO_Bus.EV_REQ_BOTH_EDGES    for either edge
+        :param callback_function:   Function to be called when/if the event occurs. This should take
+                                    two arguments: event type, and line index (so that the trigger
+                                    line can be identified if using the same callback function for
+                                    multiple lines).
+        """
 
         # Check event request is one of those defined at the top
         if event_request_type not in [GPIO_Bus.EV_REQ_RISING,
@@ -264,6 +396,7 @@ class GPIO_Bus():
         self._monitors[index] = (self._executor.submit(self._event_monitor_task, callback_function, index, line))
 
     def remove_pin_event_callback(self, index):
+        """ Remove callback event for a given pin bus index. """
         # Remove callback async function
         self._monitor_remove_pending.append(index)
 
@@ -277,7 +410,8 @@ class GPIO_Bus():
         self.remove_pin_event(index)
 
     def report_registered_events(self):
-        #TODO list all pins in the monitor list
+        """ List all pins currently being monitored, along with the events being waited for. """
+        #TODO
         pass
 
 """

--- a/src/odin_devices/gpio_bus.py
+++ b/src/odin_devices/gpio_bus.py
@@ -29,6 +29,7 @@ if sys.version_info[0] == 3:        # pragma: no cover
 else:                               # pragma: no cover
     try:
         import futures
+        FileNotFoundError = OSError
     except ImportError:
         _ASYNC_AVAIL = False
         logger.warning(

--- a/src/odin_devices/gpio_bus.py
+++ b/src/odin_devices/gpio_bus.py
@@ -110,7 +110,7 @@ class GPIO_Bus():
     def get_pin(self, index, direction, active_l=False, no_request=False):
 
         # check pin is valid and available
-        self._check_pin_avail(index)
+        if not no_request: self._check_pin_avail(index)
 
         # Create GPIO_Pin wrapper around master linebulk pin
         line = self._master_linebulk.to_list()[index]
@@ -123,8 +123,9 @@ class GPIO_Bus():
                          type = direction,
                          flags = flags,
                          default_val = 0)
-        elif line.is_requested():
+        elif line.is_requested() and not no_request:
             # Warn user if they have already requested this line, but still return it
+            # (without them asking specifically)
             logger.warning("This line is already requested, returning handle")
 
         return line
@@ -134,7 +135,7 @@ class GPIO_Bus():
 
         # Check pins are valid and available
         for index in indexes:
-            self._check_pin_avail(index, ignore_current=True)
+            if not no_request: self._check_pin_avail(index, ignore_current=True)
 
         # Create GPIO_Bulk_Pins wrapper around master linebulk pin
         lines = self._master_linebulk.get_lines(indexes)

--- a/src/odin_devices/gpio_bus.py
+++ b/src/odin_devices/gpio_bus.py
@@ -240,7 +240,15 @@ class GPIO_Bus():
 
     def register_pin_event_callback(self, index, event_request_type, callback_function):
         # Callback has 2 arguments, event and index. Event is one of those defined at the top
-        # Event request is one of those defined at the top
+
+        # Check event request is one of those defined at the top
+        if event_request_type not in [GPIO_Bus.EV_REQ_RISING,
+                GPIO_Bus.EV_REQ_FALLING,
+                GPIO_Bus.EV_REQ_BOTH_EDGES]:
+            raise GPIOException(
+                    "Invalid event type, choose from: "
+                    "GPIO_Bus.EV_REQ_RISING, GPIO_Bus.EV_REQ_FALLING, "
+                    "GPIO_Bus.EV_REQ_BOTH_EDGES")
 
         # Check module has been imported to allow asynchronous code
         if not _ASYNC_AVAIL:

--- a/src/odin_devices/gpio_bus.py
+++ b/src/odin_devices/gpio_bus.py
@@ -49,9 +49,6 @@ class GPIO_Bus():
     DIR_INPUT = gpiod.LINE_REQ_DIR_IN
     DIR_OUTPUT = gpiod.LINE_REQ_DIR_OUT
 
-    ACTIVE_L = gpiod.Line.ACTIVE_LOW
-    ACTIVE_H = gpiod.Line.ACTIVE_HIGH
-
     EVENT_RISING = gpiod.LineEvent.RISING_EDGE
     EVENT_FALLING = gpiod.LineEvent.FALLING_EDGE
 
@@ -136,14 +133,16 @@ class GPIO_Bus():
 
     def get_pin(self, index, direction, active_l=False, no_request=False):
 
-        # check pin is valid and available
-        if not no_request: self._check_pin_avail(index)
+        # check pin is valid and available.
+        # If being called with no_request=True, the pin is being returned without request, so
+        # whether the current program has requested it or not is irrelevant.
+        self._check_pin_avail(index, ignore_current=no_request)
 
         # Create GPIO_Pin wrapper around master linebulk pin
         line = self._master_linebulk.to_list()[index]
         if no_request == False and line.is_requested() == False:
             if active_l:
-                flags = LINE_REQ_FLAG_ACTIVE_LOW
+                flags = gpiod.LINE_REQ_FLAG_ACTIVE_LOW
             else:
                 flags = 0
             line.request(consumer=self._consumer_name,
@@ -168,7 +167,7 @@ class GPIO_Bus():
         lines = self._master_linebulk.get_lines(indexes)
         if no_request == False:
             if active_l:
-                flags = LINE_REQ_FLAG_ACTIVE_LOW
+                flags = gpiod.LINE_REQ_FLAG_ACTIVE_LOW
             else:
                 flags = 0
             lines.request(consumer=self._consumer_name,

--- a/src/odin_devices/gpio_bus.py
+++ b/src/odin_devices/gpio_bus.py
@@ -19,14 +19,14 @@ except ModuleNotFoundException:
 
 # If concurrence is not available, module should still be able to be used without events.
 _ASYNC_AVAIL = True
-if sys.version_info[0] == 3:
+if sys.version_info[0] == 3:        # pragma: no cover
     try:
         import concurrent.futures as futures
     except ModuleNotFoundError:
         _ASYNC_AVAIL = False
         logger.warning(
                 "concurrent.futures module not available, asynchronous events not supported")
-else:
+else:                               # pragma: no cover
     try:
         import futures
     except ImportError:

--- a/src/odin_devices/gpio_bus.py
+++ b/src/odin_devices/gpio_bus.py
@@ -149,23 +149,21 @@ class GPIO_Bus():
                          type = direction,
                          flags = flags,
                          default_val = 0)
-        elif line.is_requested() and not no_request:
-            # Warn user if they have already requested this line, but still return it
-            # (without them asking specifically)
-            logger.warning("This line is already requested, returning handle")
 
         return line
 
     def get_bulk_pins(self, indexes, direction, active_l=False, no_request=False):
-        # TODO if requested, but by current consumer, call with no_request and warn
 
         # Check pins are valid and available
+        # If being called with no_request=True, the pins are being returned without request, so
+        # whether the current program has requested any of the pins or not is irrelevant
         for index in indexes:
-            if not no_request: self._check_pin_avail(index, ignore_current=True)
+            self._check_pin_avail(index, ignore_current=no_request)
 
         # Create GPIO_Bulk_Pins wrapper around master linebulk pin
         lines = self._master_linebulk.get_lines(indexes)
-        if no_request == False:
+        any_lines_requested = [x.is_requested() for x in lines.to_list()]
+        if no_request == False and any_lines_requested == False:
             if active_l:
                 flags = gpiod.LINE_REQ_FLAG_ACTIVE_LOW
             else:

--- a/src/odin_devices/gpio_bus.py
+++ b/src/odin_devices/gpio_bus.py
@@ -1,6 +1,40 @@
-import gpiod
+import logging
+logger = logging.getLogger('odin_devices.gpio_bus')
 
-# TODO can I use with to protect the resources being lost? Pins MUST be released
+class GPIOException(Exception):
+    pass
+
+"""
+Check dependencies and environment:
+"""
+
+try:
+    import gpiod
+except ModuleNotFoundException:
+    raise GPIOException(
+            "gpiod module not found. "
+            "This module requires libgpiod to be compiled with python bindings enabled. "
+            "See https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/")
+
+# If concurrence is not available, module should still be able to be used without events.
+_ASYNC_AVAIL = True
+try:
+    import concurrent.futures
+except ModuleNotFoundException:
+    _ASYNC_AVAIL = False
+    logger.warning(
+            "concurrent.futures module not available, asynchronous events not supported")
+
+# This module requires a new enough version of libgpiod that the line.update() function exists
+try:
+    gpiod.Line.update
+except AttributeError:
+    raise GPIOException(
+            "This module requries a version of libgpiod that includes gpiod.Line.update()")
+
+"""
+GPIO Bus Class:
+"""
 
 class GPIO_Bus():
     DIR_INPUT = gpiod.LINE_REQ_DIR_IN
@@ -8,6 +42,13 @@ class GPIO_Bus():
 
     ACTIVE_L = gpiod.Line.ACTIVE_LOW
     ACTIVE_H = gpiod.Line.ACTIVE_HIGH
+
+    EVENT_RISING = gpiod.LineEvent.RISING_EDGE
+    EVENT_FALLING = gpiod.LineEvent.FALLING_EDGE
+
+    EV_REQ_RISING = gpiod.LINE_REQ_EV_RISING_EDGE
+    EV_REQ_FALLING = gpiod.LINE_REQ_EV_FALLING_EDGE
+    EV_REQ_BOTH_EDGES = gpiod.LINE_REQ_EV_BOTH_EDGES
 
     def __init__(self, width, chipno=0, system_offset=0):
         # Select the specified GPIO chip
@@ -21,6 +62,14 @@ class GPIO_Bus():
         # Set the consumer name
         self._consumer_name = "odin_gpio_bus"
 
+        # Set up for concurrency if available
+        self._executor = None       # Will manage futures for events being awaited
+        self._monitors = {}          # Will hold references to futures and related lines
+        self._monitor_remove_pending = []   # List of pin indexes that should stop monitoring
+
+    """
+    Bus and Consumer Management
+    """
     def get_consumer_name(self):
         return self._consumer_name
 
@@ -40,13 +89,32 @@ class GPIO_Bus():
 
         self._gpio_chip.get_lines(range(self._system_offset, self._system_offset + new_width))
 
+    """
+    Pin Requests
+    """
+    def _check_pin_avail(self, index, ignore_current=False):
+        self._master_linebulk.to_list()[index].update()
+        # Check if the pin is in range
+        if index >= self._width:
+            raise GPIOException ("GPIO Pin index out of range, bus width: {}".format(self._width))
+
+        if not ignore_current:
+            # Check pin is not already requested for other operations by this user
+            if self._master_linebulk.to_list()[index].is_requested():
+                raise GPIOException ("User has already requested ownership of this line")
+
+        # Check pin is not already in use by the kernel or another user
+        if self._master_linebulk.to_list()[index].is_used():
+            raise GPIOException ("This line is already in use by another user or the kernel")
+
     def get_pin(self, index, direction, active_l=False, no_request=False):
-        # TODO Check pin is within range, and unrequested
-        # TODO if requested, but by current application, call with no_request and warn
+
+        # check pin is valid and available
+        self._check_pin_avail(index)
 
         # Create GPIO_Pin wrapper around master linebulk pin
         line = self._master_linebulk.to_list()[index]
-        if no_request == False:
+        if no_request == False and line.is_requested() == False:
             if active_l:
                 flags = LINE_REQ_FLAG_ACTIVE_LOW
             else:
@@ -55,12 +123,18 @@ class GPIO_Bus():
                          type = direction,
                          flags = flags,
                          default_val = 0)
+        elif line.is_requested():
+            # Warn user if they have already requested this line, but still return it
+            logger.warning("This line is already requested, returning handle")
 
         return line
 
     def get_bulk_pins(self, indexes, direction, active_l=False, no_request=False):
-        # TODO check pin indexes are all in range, and unrequested
         # TODO if requested, but by current consumer, call with no_request and warn
+
+        # Check pins are valid and available
+        for index in indexes:
+            self._check_pin_avail(index, ignore_current=True)
 
         # Create GPIO_Bulk_Pins wrapper around master linebulk pin
         lines = self._master_linebulk.get_lines(indexes)
@@ -79,8 +153,59 @@ class GPIO_Bus():
     def release_all_consumed(self):
         self._master_linebulk.release()
 
+    """
+    Asynchronous Event Callbacks:
+    """
+    def _event_monitor_task(self, callback_function, index, line):
+        # ThreadPool futures can only be terminated individually by finishing work
+        while not index in self._monitor_remove_pending:
+            # Check non-blocking so that event monitor removal is polled
+            if line.event_wait(sec=1):
+                event = line.event_read()
+                callback_function(event.type, index)    # Call the user's callback
 
-# Example buses
+    def register_pin_event_callback(self, index, event_request_type, callback_function):
+        # Callback has 2 arguments, event and index. Event is one of those defined at the top
+        # Event request is one of those defined at the top
+
+        # check pin is valid and available
+        self._check_pin_avail(index)
+
+        # Check module has been imported to allow asynchronous code
+        if not _ASYNC_AVAIL:
+            raise GPIOException ("Asynchronous operations not available, no concurrent.futures module")
+
+        # Create event request
+        line = self._master_linebulk.to_list()[index]
+        line.request(consumer=self._consumer_name,
+                     type=event_request_type)
+
+        # Register callback
+        if self._executor == None:
+            self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=None)
+        self._monitors[index] = (self._executor.submit(self._event_monitor_task, callback_function, index, line))
+
+    def remove_pin_event_callback(self, index):
+        # Remove callback async function
+        self._monitor_remove_pending.append(index)
+
+        while not self._monitors[index].done():
+            pass
+
+        self._monitor_remove_pending.remove(index)
+        self._monitors.pop(index)
+
+        # Free pin
+        line = self.get_pin(index, None, False, True)
+        line.release()
+
+    def report_registered_events(self):
+        #TODO list all pins in the monitor list
+        pass
+
+"""
+Example Buses:
+"""
 GPIO_Zynq = GPIO_Bus(12, 0, 54)         # Width will need to match EMIO GPIO width
 GPIO_ZynqMP = GPIO_Bus(12, 0, 78)       # Width will need to match EMIO GPIO width
 

--- a/src/odin_devices/gpio_bus.py
+++ b/src/odin_devices/gpio_bus.py
@@ -49,9 +49,11 @@ class GPIO_Bus():
     DIR_INPUT = gpiod.LINE_REQ_DIR_IN
     DIR_OUTPUT = gpiod.LINE_REQ_DIR_OUT
 
+    # Event types, used when the events are reported. NOT for requests
     EVENT_RISING = gpiod.LineEvent.RISING_EDGE
     EVENT_FALLING = gpiod.LineEvent.FALLING_EDGE
 
+    # Event request types, used when creating listeners
     EV_REQ_RISING = gpiod.LINE_REQ_EV_RISING_EDGE
     EV_REQ_FALLING = gpiod.LINE_REQ_EV_FALLING_EDGE
     EV_REQ_BOTH_EDGES = gpiod.LINE_REQ_EV_BOTH_EDGES
@@ -182,7 +184,14 @@ class GPIO_Bus():
     Synchronous Event Handling:
     """
     def register_pin_event(self, index, event_request_type):
-        # Event request is one of those defined at the top
+        # Check event request is one of those defined at the top
+        if event_request_type not in [GPIO_Bus.EV_REQ_RISING,
+                GPIO_Bus.EV_REQ_FALLING,
+                GPIO_Bus.EV_REQ_BOTH_EDGES]:
+            raise GPIOException(
+                    "Invalid event type, choose from: "
+                    "GPIO_Bus.EV_REQ_RISING, GPIO_Bus.EV_REQ_FALLING, "
+                    "GPIO_Bus.EV_REQ_BOTH_EDGES")
 
         # check pin is valid and available
         self._check_pin_avail(index)

--- a/tests/test_gpio_bus.py
+++ b/tests/test_gpio_bus.py
@@ -8,6 +8,7 @@ if sys.version_info[0] == 3:    # pragma: no cover
 else:                           # pragma: no cover
     from mock import Mock, mock_open, MagicMock, patch
     ModuleNotFoundError = ImportError
+    FileNotFoundError = OSError     # Python 2 does not support FileNotFoundError
 
 # Create mocks
 sys.modules['gpiod'] = Mock()

--- a/tests/test_gpio_bus.py
+++ b/tests/test_gpio_bus.py
@@ -1,0 +1,180 @@
+
+import sys
+import pytest
+
+if sys.version_info[0] == 3:    # pragma: no cover
+    from unittest.mock import Mock, mock_open, MagicMock, patch
+else:                           # pragma: no cover
+    from mock import Mock, mock_open, MagicMock, patch
+
+# Create mocks
+sys.modules['gpiod'] = Mock()
+sys.modules['logging'] = Mock() # Track calls to logger.warning
+
+##from odin_devices.gpio_bus import GPIO_Bus, GPIO_ZynqMP, logger, GPIOException, _ASYNC_AVAIL
+
+class gpio_bus_test_fixture(object):
+
+    def __init__(self):
+        # Instantiate a basic 10-line bus with GPIO chip '1' and offset '20'
+        #self.gpio_bus_basic = GPIO_Bus(10, 1, 20);  # Instantiate a basic GPIO BUS
+        pass
+
+@pytest.fixture(scope="class")
+def test_gpio_bus():
+    test_driver_fixture = gpio_bus_test_fixture()
+    yield test_driver_fixture
+
+def raise_OSError():
+    raise OSError
+
+class TestGPIOBus():
+
+    def test_imports_noconcurrent(self, test_gpio_bus):
+        # remove concurrent reference so that on import it will fail
+        import concurrent
+        oldconcurrent = sys.modules['concurrent']
+        sys.modules['concurrent'] = None
+
+        # import with concurrent removed
+        from odin_devices.gpio_bus import GPIO_Bus, GPIOException
+
+        # Init a test bus
+        test_gpio_bus.gpio_bus_temp = GPIO_Bus(5, 1, 20)    # Test same request as before
+        test_gpio_bus.gpio_bus_temp._master_linebulk = MagicMock()  # Make sure these calls do nothing
+        test_gpio_bus.gpio_bus_temp._check_pin_avail = MagicMock()  # Make sure tests don't to verify pins
+
+        # Attempt the use of a synchronous event call (gpiod mocked), should not throw error
+        test_gpio_bus.gpio_bus_temp.register_pin_event(1, GPIO_Bus.EV_REQ_RISING)
+
+        # Attempt the use of an asynchronous event call, expecting an error thrown
+        with pytest.raises(GPIOException, match=".*Asynchronous operations not available.*"):
+            try:
+                test_gpio_bus.gpio_bus_temp.register_pin_event_callback(2, GPIO_Bus.EV_REQ_RISING, None)
+            except ModuleNotFoundError:
+                pass    # Stop trigger error causing failure if it is not handled
+
+        # Free any claimed pins
+        test_gpio_bus.gpio_bus_temp.release_all_consumed()
+
+        # Restore concurrent
+        sys.modules['cocurrent'] = oldconcurrent
+
+    def test_instantiation_chip(self, test_gpio_bus):
+        from odin_devices.gpio_bus import GPIO_Bus, GPIOException
+
+        # Create temporary test bus
+        test_gpio_bus.gpio_bus_temp = GPIO_Bus(5, 1, 20)
+
+        # Test initial chipname chosen is correct for basic GPIO instance
+        #test_gpio_bus.gpio_bus_temp.gpiod.Chip = MagicMock(return=
+        sys.modules['gpiod'].Chip.assert_called_with("/dev/gpiochip1")
+
+        # Test the correct line numbers are requested with offset
+        assert (list(test_gpio_bus.gpio_bus_temp._gpio_chip.get_lines.call_args[0][0]) == [20,21,22,23,24])
+
+        # Test offset correctly stored
+        assert test_gpio_bus.gpio_bus_temp._width == 5
+
+    def test_invalid_gpio_chip(self, test_gpio_bus):
+        from odin_devices.gpio_bus import GPIO_Bus, GPIOException
+        # Test the driver's reaction to an FileNotFoundError thrown on call to gpiod.Chip()
+
+        # Set the side-effect of calling gpiod.Chip() as FileNotFoundError
+        sys.modules['gpiod'].Chip.side_effect = FileNotFoundError
+
+        # Check that the FileNotFoundError triggers a GPIOError which warns about gpiochip
+        with pytest.raises(GPIOException, match=".*gpiochip.*"):
+            try:
+                test.gpio_bus.gpio_bus_temp = GPIO_Bus(5, 1, 20)    # Test same request as before
+            except FileNotFoundError:
+                pass    # Stop trigger error causing failure if it is not handled
+
+        # Remove the error side-effect
+        sys.modules['gpiod'].Chip.side_effect = None
+
+    def test_invalid_line_range(self, test_gpio_bus):
+        from odin_devices.gpio_bus import GPIO_Bus, GPIOException
+        # Test instantiation with invalid linebulk ranges (pins not available on the gpiochip)
+        # In this case, gpiod throws an OSError
+
+        # Set the side-effect of calling get_lines as OSError
+        #sys.modules['gpiod'].Chip.get_lines.side_effect = OSError
+
+        # Create a new chip instance to use
+        chipmock = sys.modules['gpiod'].Chip(None)
+        chipmock.get_lines.side_effect = FileNotFoundError # Calling get_lines on this chip will fail
+        sys.modules['gpiod'].Chip.side_effect = chipmock    # Return our mock chip
+
+        # Check that OSError on call to get_lines will cause an error description for range
+        with pytest.raises(GPIOException, match=".*out of range.*"):
+            try:
+                test_gpio_bus.gpio_bus_temp = GPIO_Bus(5, 1, 20)    # Test same request as before
+                print(test_gpio_bus.gpio_bus_temp._gpio_chip.get_lines.call_args)
+                print(sys.modules['gpiod'].Chip.get_lines.call_args)
+                print(chipmock.get_lines.call_args)
+                print(chipmock.get_lines.mock_calls)
+            except OSError:
+                print("An OSError was triggered")
+                pass    # Stop trigger error causing failure if it is not handled
+            except exception as e:
+                print("Other error: ", e)
+
+       # Remove the error side-effect
+        sys.modules['gpiod'].Chip.get_lines.side_effect = None
+
+    def test_consumer_naming(self, test_gpio_bus):
+        from odin_devices.gpio_bus import GPIO_Bus, GPIOException
+        # Test that when the consumer name is changed, the correct name is used to claim lines
+        # inside the calls to gpiod.
+
+        # Init a test bus of width 5
+        test_gpio_bus.gpio_bus_temp = GPIO_Bus(5, 0, 0)
+
+        # Mock the linebulk so that it returns a free Line object mock
+        mockline = sys.modules['gpiod'].Line()
+        mockline.is_requested.return_value = False
+        mockline.is_used.return_value = False
+        test_gpio_bus.gpio_bus_temp._master_linebulk.to_list.return_value = [mockline]
+
+        # Set a non-default consumer name
+        default_consumer_name = test_gpio_bus.gpio_bus_temp.get_consumer_name()
+        test_gpio_bus.gpio_bus_temp.set_consumer_name("nonstandard_consumername")
+
+        # Check sure we have actually set using a new name
+        assert test_gpio_bus.gpio_bus_temp.get_consumer_name() != default_consumer_name
+
+        # Check sure the new consumer name is sent to gpiod
+        test_gpio_bus.gpio_bus_temp.get_pin(0, GPIO_Bus.DIR_INPUT, False, False)
+        mockline.request.assert_called_with(consumer="nonstandard_consumername",
+                type=GPIO_Bus.DIR_INPUT,
+                default_val=0,flags=0)
+
+    def test_width_setting(self, test_gpio_bus):
+        from odin_devices.gpio_bus import GPIO_Bus, GPIOException
+        # Test that the width changes correctly, and properly frees any lines that would become
+        # unusable in the event of a reduced width. Also checks invalid widths.
+
+        # Init a test bus of width 5 with no offset
+        test_gpio_bus.gpio_bus_temp = GPIO_Bus(5, 0, 0)
+
+        # Check the width has been correctly set as 5
+        assert test_gpio_bus.gpio_bus_temp._width == 5
+
+        # Set gpiod get_lines to return a list of 10 lines (for checking this becomes the linebulk)
+        mocklines = [sys.modules['gpiod'].Line()] * 10
+        test_gpio_bus.gpio_bus_temp._gpio_chip.get_lines.return_value = mocklines
+
+        # Increase width to 10
+        test_gpio_bus.gpio_bus_temp.set_width(10)
+
+        # Check that gpiod get_lines called with correct range, width is 10 and assignment is made
+        test_gpio_bus.gpio_bus_temp._gpio_chip.get_lines.assert_called_with(range(0, 10))
+        assert test_gpio_bus.gpio_bus_temp._width == 10
+        assert test_gpio_bus.gpio_bus_temp._master_linebulk == mocklines
+
+        # Check that creating a bus with a range less than 1 results in error
+        with pytest.raises(GPIOException, match=".*Width supplied is invalid.*"):
+            GPIO_Bus(0, 0, 0)
+        with pytest.raises(GPIOException, match=".*Width supplied is invalid.*"):
+            GPIO_Bus(-1, 0, 0)

--- a/tests/test_gpio_bus.py
+++ b/tests/test_gpio_bus.py
@@ -4,6 +4,7 @@ import pytest
 
 if sys.version_info[0] == 3:    # pragma: no cover
     from unittest.mock import Mock, mock_open, MagicMock, patch
+    from importlib import reload
 else:                           # pragma: no cover
     from mock import Mock, mock_open, MagicMock, patch
     ModuleNotFoundError = ImportError
@@ -12,7 +13,8 @@ else:                           # pragma: no cover
 sys.modules['gpiod'] = Mock()
 sys.modules['logging'] = Mock() # Track calls to logger.warning
 
-##from odin_devices.gpio_bus import GPIO_Bus, GPIO_ZynqMP, logger, GPIOException, _ASYNC_AVAIL
+#import odin_devices.gpio_bus        # Needs direct import so module can be reloaded live
+#from odin_devices.gpio_bus import GPIO_Bus, GPIO_ZynqMP, logger, GPIOException, _ASYNC_AVAIL
 
 class gpio_bus_test_fixture(object):
 
@@ -43,6 +45,8 @@ class TestGPIOBus():
             sys.modules['futures'] = None
 
         # import with concurrent removed
+        import odin_devices.gpio_bus
+        reload(odin_devices.gpio_bus)
         from odin_devices.gpio_bus import GPIO_Bus, GPIOException
 
         # Init a test bus
@@ -66,8 +70,12 @@ class TestGPIOBus():
         # Restore concurrent
         if sys.version_info[0] == 3:    #pragma: no cover
             sys.modules['concurrent'] = oldconcurrent
+
         else:                           #pragma: no cover
             sys.modules['futures'] = oldfutures
+
+        import odin_devices.gpio_bus
+        reload(odin_devices.gpio_bus)
 
     def test_instantiation_chip(self, test_gpio_bus):
         from odin_devices.gpio_bus import GPIO_Bus, GPIOException

--- a/tests/test_gpio_bus.py
+++ b/tests/test_gpio_bus.py
@@ -6,6 +6,7 @@ if sys.version_info[0] == 3:    # pragma: no cover
     from unittest.mock import Mock, mock_open, MagicMock, patch
 else:                           # pragma: no cover
     from mock import Mock, mock_open, MagicMock, patch
+    ModuleNotFoundError = ImportError
 
 # Create mocks
 sys.modules['gpiod'] = Mock()
@@ -32,9 +33,14 @@ class TestGPIOBus():
 
     def test_imports_noconcurrent(self, test_gpio_bus):
         # remove concurrent reference so that on import it will fail
-        import concurrent
-        oldconcurrent = sys.modules['concurrent']
-        sys.modules['concurrent'] = None
+        if sys.version_info[0] == 3:    #pragma: no cover
+            import concurrent
+            oldconcurrent = sys.modules['concurrent']
+            sys.modules['concurrent'] = None
+        else:                           #pragma: no cover
+            import futures
+            oldfutures = sys.modules['futures']
+            sys.modules['futures'] = None
 
         # import with concurrent removed
         from odin_devices.gpio_bus import GPIO_Bus, GPIOException
@@ -58,7 +64,10 @@ class TestGPIOBus():
         test_gpio_bus.gpio_bus_temp.release_all_consumed()
 
         # Restore concurrent
-        sys.modules['cocurrent'] = oldconcurrent
+        if sys.version_info[0] == 3:    #pragma: no cover
+            sys.modules['concurrent'] = oldfutures
+        else:                           #pragma: no cover
+            sys.modules['futures'] = oldfutures
 
     def test_instantiation_chip(self, test_gpio_bus):
         from odin_devices.gpio_bus import GPIO_Bus, GPIOException

--- a/tests/test_gpio_bus.py
+++ b/tests/test_gpio_bus.py
@@ -14,7 +14,7 @@ sys.modules['gpiod'] = Mock()
 sys.modules['logging'] = Mock() # Track calls to logger.warning
 
 #import odin_devices.gpio_bus        # Needs direct import so module can be reloaded live
-#from odin_devices.gpio_bus import GPIO_Bus, GPIO_ZynqMP, logger, GPIOException, _ASYNC_AVAIL
+from odin_devices.gpio_bus import GPIO_Bus, GPIO_ZynqMP, logger, GPIOException, _ASYNC_AVAIL
 
 class gpio_bus_test_fixture(object):
 
@@ -70,12 +70,15 @@ class TestGPIOBus():
         # Restore concurrent
         if sys.version_info[0] == 3:    #pragma: no cover
             sys.modules['concurrent'] = oldconcurrent
-
         else:                           #pragma: no cover
             sys.modules['futures'] = oldfutures
-
         import odin_devices.gpio_bus
         reload(odin_devices.gpio_bus)
+        from odin_devices.gpio_bus import GPIO_Bus, GPIOException
+
+        # Check async was restored (stops later async test failing)
+        from odin_devices.gpio_bus import _ASYNC_AVAIL
+        assert(_ASYNC_AVAIL)
 
     def test_instantiation_chip(self, test_gpio_bus):
         from odin_devices.gpio_bus import GPIO_Bus, GPIOException


### PR DESCRIPTION
Adding this as a PR because it has a test script and should not damage coverage.

gpiod allows control of GPIO lines from userspace when gpiochips, which are listed in /dev/. This is the newer way of accessing GPIO, and has been in the kernel since 4.6.0. gpiod provides bindings for python.

Pins are provided and 'consumed' by software once they are requested. This driver has been written to attempt to abstract away this process and simplify the numbering scheme (system numbering offsets depending on architecture) by defining standard buses for architectures. The currently includes the Zynq and ZynqMP.

There is also some support for event handling added. The synchronous functionality means pin events can be registered and then polled as desired. The asynchronous functionality uses a ThreadPoolExecutor to monitor registered events and call a user-specified callback when the events occur, with information including the event type and pin the event was triggered on.