### PR TITLE
Add si534x

### DIFF
--- a/src/odin_devices/gpio_bus.py
+++ b/src/odin_devices/gpio_bus.py
@@ -1,0 +1,287 @@
+import logging
+import sys
+logger = logging.getLogger('odin_devices.gpio_bus')
+
+class GPIOException(Exception):
+    pass
+
+"""
+Check dependencies and environment:
+"""
+
+try:
+    import gpiod
+except ModuleNotFoundException:
+    raise GPIOException(
+            "gpiod module not found. "
+            "This module requires libgpiod to be compiled with python bindings enabled. "
+            "See https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/about/")
+
+# If concurrence is not available, module should still be able to be used without events.
+_ASYNC_AVAIL = True
+if sys.version_info[0] == 3:        # pragma: no cover
+    try:
+        import concurrent.futures as futures
+    except ModuleNotFoundError:
+        _ASYNC_AVAIL = False
+        logger.warning(
+                "concurrent.futures module not available, asynchronous events not supported")
+else:                               # pragma: no cover
+    try:
+        import futures
+    except ImportError:
+        _ASYNC_AVAIL = False
+        logger.warning(
+                "concurrent.futures module not available, asynchronous events not supported")
+
+# This module requires a new enough version of libgpiod that the line.update() function exists
+try:
+    gpiod.Line.update
+except AttributeError:
+    raise GPIOException(
+            "This module requries a version of libgpiod that includes gpiod.Line.update()")
+
+"""
+GPIO Bus Class:
+"""
+
+class GPIO_Bus():
+    DIR_INPUT = gpiod.LINE_REQ_DIR_IN
+    DIR_OUTPUT = gpiod.LINE_REQ_DIR_OUT
+
+    # Event types, used when the events are reported. NOT for requests
+    EVENT_RISING = gpiod.LineEvent.RISING_EDGE
+    EVENT_FALLING = gpiod.LineEvent.FALLING_EDGE
+
+    # Event request types, used when creating listeners
+    EV_REQ_RISING = gpiod.LINE_REQ_EV_RISING_EDGE
+    EV_REQ_FALLING = gpiod.LINE_REQ_EV_FALLING_EDGE
+    EV_REQ_BOTH_EDGES = gpiod.LINE_REQ_EV_BOTH_EDGES
+
+    def __init__(self, width, chipno=0, system_offset=0):
+        # Check width is valid
+        if not width > 0:
+            raise GPIOException(
+                    "Width supplied is invalid. Please specify a bus width above 0")
+
+        # Select the specified GPIO chip
+        try:
+            self._gpio_chip = gpiod.Chip("/dev/gpiochip" +str(chipno))
+        except FileNotFoundError:
+            raise GPIOException(
+                    "gpiochip not found, check /dev/gpiochip* for chip numbers present")
+
+        # Place the chosen lines into a bulk for offset removal. Not requested until use.
+        self._system_offset = system_offset
+        self._width = width
+        try:
+            self._master_linebulk = self._gpio_chip.get_lines(range(system_offset, system_offset+width))
+        except OSError:
+            raise GPIOException(
+                    "Selected lines were not available for this chip. "
+                    "Check if numbering is out of range")
+
+        # Set the consumer name
+        self._consumer_name = "odin_gpio_bus"
+
+        # Set up for concurrency if available
+        self._executor = None       # Will manage futures for events being awaited
+        self._monitors = {}          # Will hold references to futures and related lines
+        self._monitor_remove_pending = []   # List of pin indexes that should stop monitoring
+
+    """
+    Bus and Consumer Management
+    """
+    def get_consumer_name(self):
+        return self._consumer_name
+
+    def set_consumer_name(self, consumer_name):
+        self._consumer_name = consumer_name
+
+    def get_width(self):
+        return self._width
+
+    def set_width(self, new_width):
+        # Create a new linebulk, since this does not imply ownership.
+
+        # Free pins that would become inaccessible
+        if new_width < self._width:
+            for i in range(new_width, self._width):
+                self._master_linebulk.to_list()[i].release()
+
+        self._master_linebulk = self._gpio_chip.get_lines(range(self._system_offset, self._system_offset + new_width))
+        self._width = new_width
+
+    """
+    Pin Requests
+    """
+    def _check_pin_avail(self, index, ignore_current=False):
+        # Check if the pin is in range
+        if index >= self._width:
+            raise GPIOException ("GPIO Pin index out of range, bus width: {}".format(self._width))
+        elif index < 0:
+            raise GPIOException ("Gpio Pin index cannot be negative")
+
+        self._master_linebulk.to_list()[index].update()     # Sync line info with kernel
+
+        if not ignore_current:
+            # Check pin is not already requested for other operations by this user
+            if self._master_linebulk.to_list()[index].is_requested():
+                raise GPIOException ("User has already requested ownership of this line")
+
+        # Check pin is not already in use by the kernel or another user
+        if self._master_linebulk.to_list()[index].is_used():
+            raise GPIOException ("This line is already in use by another user or the kernel")
+
+    def get_pin(self, index, direction, active_l=False, no_request=False):
+
+        # check pin is valid and available.
+        # If being called with no_request=True, the pin is being returned without request, so
+        # whether the current program has requested it or not is irrelevant.
+        self._check_pin_avail(index, ignore_current=no_request)
+
+        # Create GPIO_Pin wrapper around master linebulk pin
+        line = self._master_linebulk.to_list()[index]
+        if no_request == False and line.is_requested() == False:
+            if active_l:
+                flags = gpiod.LINE_REQ_FLAG_ACTIVE_LOW
+            else:
+                flags = 0
+            line.request(consumer=self._consumer_name,
+                         type = direction,
+                         flags = flags,
+                         default_val = 0)
+
+        return line
+
+    def get_bulk_pins(self, indexes, direction, active_l=False, no_request=False):
+
+        # Check pins are valid and available
+        # If being called with no_request=True, the pins are being returned without request, so
+        # whether the current program has requested any of the pins or not is irrelevant
+        for index in indexes:
+            self._check_pin_avail(index, ignore_current=no_request)
+
+        # Create GPIO_Bulk_Pins wrapper around master linebulk pin
+        lines = self._master_linebulk.get_lines(indexes)
+        any_lines_requested = [x.is_requested() for x in lines.to_list()]
+        if no_request == False and any_lines_requested == False:
+            if active_l:
+                flags = gpiod.LINE_REQ_FLAG_ACTIVE_LOW
+            else:
+                flags = 0
+            lines.request(consumer=self._consumer_name,
+                         type = direction,
+                         flags = active,
+                         default_val = 0)
+
+        return lines
+
+    def release_all_consumed(self):
+        self._master_linebulk.release()
+
+    """
+    Synchronous Event Handling:
+    """
+    def register_pin_event(self, index, event_request_type):
+        # Check event request is one of those defined at the top
+        if event_request_type not in [GPIO_Bus.EV_REQ_RISING,
+                GPIO_Bus.EV_REQ_FALLING,
+                GPIO_Bus.EV_REQ_BOTH_EDGES]:
+            raise GPIOException(
+                    "Invalid event type, choose from: "
+                    "GPIO_Bus.EV_REQ_RISING, GPIO_Bus.EV_REQ_FALLING, "
+                    "GPIO_Bus.EV_REQ_BOTH_EDGES")
+
+        # check pin is valid and available
+        self._check_pin_avail(index)
+
+        # Create event request
+        line = self._master_linebulk.to_list()[index]
+        line.request(consumer=self._consumer_name,
+                     type=event_request_type)
+
+        return line
+
+    def remove_pin_event(self, index):
+        # Free pin
+        line = self.get_pin(index, None, False, True)
+        line.release()
+
+    def wait_pin_event(self, index, timeout_s=0):
+        # Directly wraps the gpiod call with a check. Blocking if no timeout is supplied.
+        # event description if event occured, False if timeout
+
+        # Check this pin has been registered for an event
+        line = self.get_pin(index, None, False, True)
+        line.update()
+        if not line.is_requested():
+            raise GPIOException(
+                    "This line is not registered to wait for events. "
+                    "Try calling register_pin_event() first")
+
+        event_found = line.event_wait(sec=timeout_s)
+
+        if event_found:
+            return line.event_read()
+        else:
+            return False
+
+    """
+    Asynchronous Event Callbacks:
+    """
+    def _event_monitor_task(self, callback_function, index, line):
+        # ThreadPool futures can only be terminated individually by finishing work
+        while not index in self._monitor_remove_pending:
+            # Check non-blocking so that event monitor removal is polled
+            if line.event_wait(sec=1):
+                event = line.event_read()
+                callback_function(event.type, index)    # Call the user's callback
+
+    def register_pin_event_callback(self, index, event_request_type, callback_function):
+        # Callback has 2 arguments, event and index. Event is one of those defined at the top
+
+        # Check event request is one of those defined at the top
+        if event_request_type not in [GPIO_Bus.EV_REQ_RISING,
+                GPIO_Bus.EV_REQ_FALLING,
+                GPIO_Bus.EV_REQ_BOTH_EDGES]:
+            raise GPIOException(
+                    "Invalid event type, choose from: "
+                    "GPIO_Bus.EV_REQ_RISING, GPIO_Bus.EV_REQ_FALLING, "
+                    "GPIO_Bus.EV_REQ_BOTH_EDGES")
+
+        # Check module has been imported to allow asynchronous code
+        if not _ASYNC_AVAIL:
+            raise GPIOException ("Asynchronous operations not available, no concurrent.futures module")
+
+        # Create and make event request
+        line = self.register_pin_event(index, event_request_type)
+
+        # Register callback
+        if self._executor == None:
+            self._executor = futures.ThreadPoolExecutor(max_workers=None)
+        self._monitors[index] = (self._executor.submit(self._event_monitor_task, callback_function, index, line))
+
+    def remove_pin_event_callback(self, index):
+        # Remove callback async function
+        self._monitor_remove_pending.append(index)
+
+        while not self._monitors[index].done():
+            pass
+
+        self._monitor_remove_pending.remove(index)
+        self._monitors.pop(index)
+
+        # Free pin
+        self.remove_pin_event(index)
+
+    def report_registered_events(self):
+        #TODO list all pins in the monitor list
+        pass
+
+"""
+Example Buses:
+"""
+GPIO_Zynq = GPIO_Bus(12, 0, 54)         # Width will need to match EMIO GPIO width
+GPIO_ZynqMP = GPIO_Bus(12, 0, 78)       # Width will need to match EMIO GPIO width
+

--- a/src/odin_devices/si534x.py
+++ b/src/odin_devices/si534x.py
@@ -1,0 +1,312 @@
+
+
+class _SI534x:
+
+    class _BitField():
+        def __init__(self, page, start_register, start_bit_pos, bit_width, parent_device):
+            self.page = page
+            self.start_register = start_retister
+            self.start_bit_pos = start_bit_pos
+            self.bit_width = bit_width
+            self.parent_device = parent_device
+
+        def write(data):
+            if type(data) == int:           # Convert value to list of bytes
+                # Check data fits in desired bit width
+                if data >= (0b1 << bit_width):
+                    #TODO Throw data size error
+                    pass
+
+                list_data = []
+                while (data > 0xFF):
+                    list_data.insert(0, 0xFF & data)
+                    data = data >> 8
+
+                # Send data
+                self.parent_device._write_registers(list_data, len(list_data), self.page, self.start_register, self.start_bit_pos, self.bit_width)
+
+            elif type(data) == list:        # Send list of bytes directly
+                # Check list fits within bit width  (Extra MSBs to boundary ignored)
+                if len(data) > ((self.bit_width % 8) + 1):
+                    #TODO Throw data size error
+                    pass
+
+                # Send data
+                self.parent_device._write_registers(data, len(data), self.page, self.start_register, self.start_bit_pos, self.bit_width)
+
+        def read():
+            return self.parent_device.chosen_bytes_read(self.page, self.start_register, self.start_bit_pos, self.bit_width)
+
+    class _Channel_BitField(_BitField):
+        def __init__(self, page, first_channel_register, start_bit_pos, bit_width, parent_device, num_channels, channel_width):
+            # bit_width is the width of this field, and channel_width is the width of the set of channel-mapped fields.
+
+            # Init shared fields using superclass
+            super(_BitField, self).__init__(page, start_register, start_bit_pos, bit_width, parent_device)
+
+            # Init additional channel-specific fields
+            self.num_channels = num_channels
+            self.channel_width = channel_width
+            self.first_channel_start_register = first_channel_register  # Holds the static start of the field
+            # start_register now becomes a dynamic value, set per channel on read / writes.
+
+        def write(data, channel_num):
+            # Check channel number is valid
+            if channel_num >= self.num_channels:
+                #TODO throw channel number error
+                pass
+
+            # Temporarily offset the _BitField start register
+            self.start_register = self.first_channel_start_register
+            self.start_register += self.channel_width * channel_num
+
+            # Call normal _BitField write function
+            super(_BitField, self).write(data)
+
+        def read(channel_num):
+            # Check channel number is valid
+            if channel_num >= self.num_channels:
+                #TODO throw channel number error
+                pass
+
+            # Temporarily offset the _BitField start register
+            self.start_register = self.first_channel_start_register
+            self.start_register += self.channel_width * channel_num
+
+            # Call normal _BitField read function
+            return super(_BitField, self).read()
+
+    class _MultiSynth_BitField(_BitField):
+        def __init__(self, page, synth0_register, start_bit_pos, bit_width, parent_device, num_multisynths, synth_width):
+            # bit_width is the width of this field, and synth_width is the width between adjacent
+            # multi-synth mapped fields.
+
+            # Init shared fields using superclass
+            super(_BitField, self).__init__(page, synth0_register, start_bit_pos, bit_width, parent_device)
+
+            # Init additional multisynth-specific fields
+            self.num_multisyths = num_multisynths
+            self.synth_width = synth_width
+            self.synth0_register = synth0_register  # Static first synth register position without offset
+            # start_register now becomes a dynamic value, set per multisynth on read/writes
+
+        def write(data, synth_num):
+            # Check synth number is valid
+            if synth_num >= self.num_multisynths:
+                #TODO throw error
+                pass
+
+            # Temporarily offset the _BitField start register
+            self.start_register = self.synth0_register
+            self.start_register += self.synth_width * synth_num
+
+            # Call normal _BitField write function
+            super(_BitField, self).write(data)
+
+        def read(synth_num):
+            # Check channel number is valid
+            if synth_num >= self.num_multisynths:
+                #TODO throw error
+                pass
+
+            # Temporarily offset the _BitField start register
+            self.start_register = self.synth0_register
+            self.start_register += self.synth_width * synth_num
+
+            # Call normal _BitField read functions
+            return super(_BitField, self).read()
+
+    # Mapping of registers expected to be present when exporting a register map that could be later
+    # programmed back into the device. It is easier to specify ranges and invalid registers instead
+    # of listing 'allowed' registers. Each page can have multiple ranges. This is based on an
+    # example exported register map CSV from ClockBuilder Pro.
+    #                               {page : [range0,
+    #                                        range1...]
+    # Where ranges are defined as tuples of start, end and invalid values as a list:
+    #                                        (start, end, [invalid value list])
+    _regmap_pages_register_ranges = {0x00 : [(0x01, 0x1E, [0x10, 0x15, 0x1B]),
+                                             (0x2B, 0x69, [0x3E])],
+                                     0x01 : [(0x02, 0x02, []),
+                                             (0x12, 0x1A, [0x16]),
+                                             (0x26, 0x42, [0x2A])],
+                                     0x02 : [(0x06, 0x3E, [0x07, 0x30]),
+                                             (0X50, 0x55, []),
+                                             (0x5C, 0x61, []),
+                                             (0x6B, 0x72, []),
+                                             (0x8A, 0x99, [0x92, 0x93, 0x95, 0x98]),
+                                             (0x9D, 0x9F, []),
+                                             (0xA9, 0xAB, []),
+                                             (0xB7, 0xB7, [])],
+                                     0x03 : [(0x02, 0x2D, []),
+                                             (0x38, 0x52, [0x3A]),
+                                             (0x59, 0x60, [])],
+                                     0x04 : [(0x87, 0x87, [])],
+                                     0x05 : [(0x08, 0x21, [0x14, 0x20]),
+                                             (0x2A, 0x3E, [0x30, 0x3A, 0x3B, 0x3C]),
+                                             (0x89, 0x8A, []),
+                                             (0x9B, 0xA6, [0x9C, 0xA3, 0xA4, 0xA5])],
+                                     0x08 : [(0x02, 0x61, [])],
+                                     0x09 : [(0x0E, 0x0E, []),
+                                             (0x43, 0x43, []),
+                                             (0x49, 0x4A, []),
+                                             (0x4E, 0x4F, []),
+                                             (0x5E, 0x5E, [])],
+                                     0x0A : [(0x02, 0x05, []),
+                                             (0x14, 0x14, []),
+                                             (0x1A, 0x1A, []),
+                                             (0x20, 0x20, []),
+                                             (0x26, 0x26, [])],
+                                     0x0B : [(0x44, 0x4A, [0x45, 0x49]),
+                                             (0x57, 0x58, [])]
+                                     }
+
+    # The register maps to be written to the device require a preamble and postamble that write
+    # registers that place the device into an acceptable start state.
+    #                            [(page, register, value),...]
+    _regmap_preamble_sequence =  [(0x0B, 0x24, 0xC0),
+                                  (0x0B, 0x25, 0x00),
+                                  (0x05, 0x40, 0x01)]
+    _regmap_postamble_sequence = [(0x05, 0x14, 0x01),
+                                  (0x00, 0x1C, 0x01),
+                                  (0x05, 0x40, 0x00),
+                                  (0x0B, 0x24, 0xC3),
+                                  (0x0B, 0x25, 0x02)]
+
+    def __init__(self, num_channels, num_multisynths, channel_reg_offset, i2c_address=None, spi_device=None,
+                 LOS_line=None, LOL_Line=None, INT_Line=None):
+        #TODO Initiate chosen interface (set chosen read/write functions)
+        if i2c_address is not None:
+            #TODO init I2C
+
+            self._write_registers = self._bytes_write_i2c
+            self.chosen_bytes_read = self._bytes_read_i2c
+        elif spi_device is not None:
+            #TODO init SPI
+
+            # Set the field byte access functions
+            self._write_registers = self._bytes_write_spi
+            self.chosen_bytes_read = self._bytes_read_spi
+        else:
+            #TODO throw error
+            pass
+
+
+        #TODO define static fields
+        self._output_driver_OUTALL_DISABLE_LOW = _BitField(page=0x01,
+                                                           start_register = 0x02,
+                                                           start_bit_pos = 0, bit_width = 1,
+                                                           parent_device = self)
+
+        #TODO define channel-mapped fields
+        self._output_driver_cfg_PDN = _Channel_BitField(page=0x01,
+                                                        first_channel_register = 0x08 + channel_reg_offset * 0x05,
+                                                        start_bit_pos = 0,
+                                                        bit_width = 1,
+                                                        parent_device = self,
+                                                        num_channels = num_channels,
+                                                        channel_width = 0x05)
+        self._output_driver_cfg_OE = _Channel_BitField(page=0x01,
+                                                       first_channel_register = 0x08 + channel_reg_offset * 0x05,
+                                                       start_bit_pos = 1,
+                                                       bit_width = 1,
+                                                       parent_device = self,
+                                                       num_channels = num_channels,
+                                                       channel_width = 0x05)
+
+
+        #TODO perform device init
+
+    def _bytes_write_i2c(self, bytes_out,  bytes_out_length, page, start_register, start_bit, width_bits):
+        pass
+
+    def _bytes_read_i2c(self, page, start_register, start_bit, width_bits):
+        pass
+
+    def _bytes_write_spi(self, bytes_out,  bytes_out_length, page, start_register, start_bit, width_bits):
+        pass
+
+    def _bytes_read_spi(self, page, start_register, start_bit, width_bits):
+        pass
+
+    #TODO add functions for desirable option changes
+
+
+    """
+    Register Map File Functions
+    """
+    def apply_register_map(self, mapfile_csv_location, verify=False):
+        #TODO update this text
+        """
+        Write configuration from a register map generated with DSPLLsim.
+        Since the map is register rather than value-based, there is no need to make use
+        of the _Field access functions.
+
+        :param mapfile_location: location of register map file to be read
+        :param verify: Boolean. If true, read registers back to verify they are written correctly.
+        """
+        with open(mapfile_csv_location) as csvfile:
+            csv_reader = csv.reader(csvfile, delimiter=',')
+            for row in csv_reader:
+                # The register map starts after general information is printed preceded by '#'
+                if row[0] != '#':
+                    # Extract register-value pairing from register map
+                    page_register = int(row[0], 0)  # 0x prefix detected automatically
+                    value = int(row[1], 0)          # 0x prefix detected automatically
+                    register = page_register & 0xFF         # Lower byte
+                    page = (page_register & 0xFF00) >> 16   # Upper byte
+
+                    # Write register value (whole byte at a time)
+                    logger.info(
+                            "Writing page 0x{:02X} register 0x{:02X} with value {:02X}".format(page,
+                                                                                               register,
+                                                                                               value))
+                    self._write_registers([value], 1, page, register, 7, 8)
+
+                    if verify:
+                        verify_value = self._read_registers(page, register, 7, 0)
+                        logger.debug("Verifying value written ({:b}) against re-read: {:b}".format(
+                            value,verify_value))
+                        if verify_value != value:
+                            raise self.CommsException(
+                                    "Write of byte to register {} failed.".format(register))
+
+        # ICAL-sensitive registers will have been modified during this process
+        #TODO if ICAL (or another finishing command) is actually still relevant
+
+    def export_register_map(self, mapfile_location):
+        """
+        Generate a register map file using the current settings in device control
+        registers. This file can then be loaded using apply_register_map(filename).
+
+        :param mapfile_location: location of register map file that will be written to.
+        """
+        with open(mapfile_csv_location, 'w') as csv_file:
+            csv_file.write("# This register map has been generated for the odin-devices SI5324 driver.\n")
+            csv_writer = csv.writer(csv_file, delimiter=',')
+
+            # The registers that will be read are the ones found in output register
+            # maps from DSPLLsim.
+            for page_register in SI534x._regmap_registers:
+
+                #TODO potentially include any registers that read as 0 for triggers, that should not be
+                # included in a write map, or need their values changing (like SI5342 ICAL)
+
+                value = self._read_registers(page, register)
+                logger.info("Read register {}: {:02X}".format(register, value))
+                f.write("{}, {:02X}h\n".format(register, value))
+
+            logger.info("Register map extraction complete, to file: {}".format(mapfile_location))
+
+class SI5345 (_SI534x):
+    def __init__(self, i2c_address=None, spi_device=None):
+        super(SI5345, self).__init__(12, 0, i2c_address, spi_device)
+
+
+class SI5344 (_SI534x):
+    def __init__(self, i2c_address=None, spi_device=None):
+        super(SI5345, self).__init__(4, 2, i2c_address, spi_device)
+
+
+class SI5342 (_SI534x):
+    def __init__(self, i2c_address=None, spi_device=None):
+        super(SI5345, self).__init__(2, 2, i2c_address, spi_device)

--- a/src/odin_devices/si534x.py
+++ b/src/odin_devices/si534x.py
@@ -118,7 +118,9 @@ class _SI534x:
             # Call normal _BitField read functions
             return super(_BitField, self).read()
 
-    # Mapping of registers expected to be present when exporting a register map that could be later
+    class _regmap_generator(object):
+        _regmap_pages = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x08, 0x09, 0x0A, 0x0B]
+        # Mapping of registers expected to be present when exporting a register map that could be later
     # programmed back into the device. It is easier to specify ranges and invalid registers instead
     # of listing 'allowed' registers. Each page can have multiple ranges. This is based on an
     # example exported register map CSV from ClockBuilder Pro.
@@ -126,41 +128,88 @@ class _SI534x:
     #                                        range1...]
     # Where ranges are defined as tuples of start, end and invalid values as a list:
     #                                        (start, end, [invalid value list])
-    _regmap_pages_register_ranges = {0x00 : [(0x01, 0x1E, [0x10, 0x15, 0x1B]),
-                                             (0x2B, 0x69, [0x3E])],
-                                     0x01 : [(0x02, 0x02, []),
-                                             (0x12, 0x1A, [0x16]),
-                                             (0x26, 0x42, [0x2A])],
-                                     0x02 : [(0x06, 0x3E, [0x07, 0x30]),
-                                             (0X50, 0x55, []),
-                                             (0x5C, 0x61, []),
-                                             (0x6B, 0x72, []),
-                                             (0x8A, 0x99, [0x92, 0x93, 0x95, 0x98]),
-                                             (0x9D, 0x9F, []),
-                                             (0xA9, 0xAB, []),
-                                             (0xB7, 0xB7, [])],
-                                     0x03 : [(0x02, 0x2D, []),
-                                             (0x38, 0x52, [0x3A]),
-                                             (0x59, 0x60, [])],
-                                     0x04 : [(0x87, 0x87, [])],
-                                     0x05 : [(0x08, 0x21, [0x14, 0x20]),
-                                             (0x2A, 0x3E, [0x30, 0x3A, 0x3B, 0x3C]),
-                                             (0x89, 0x8A, []),
-                                             (0x9B, 0xA6, [0x9C, 0xA3, 0xA4, 0xA5])],
-                                     0x08 : [(0x02, 0x61, [])],
-                                     0x09 : [(0x0E, 0x0E, []),
-                                             (0x43, 0x43, []),
-                                             (0x49, 0x4A, []),
-                                             (0x4E, 0x4F, []),
-                                             (0x5E, 0x5E, [])],
-                                     0x0A : [(0x02, 0x05, []),
-                                             (0x14, 0x14, []),
-                                             (0x1A, 0x1A, []),
-                                             (0x20, 0x20, []),
-                                             (0x26, 0x26, [])],
-                                     0x0B : [(0x44, 0x4A, [0x45, 0x49]),
-                                             (0x57, 0x58, [])]
-                                     }
+
+        _regmap_pages_register_ranges = {0x00 : [(0x01, 0x1E, [0x10, 0x15, 0x1B]),
+                                                 (0x2B, 0x69, [0x3E])],
+                                         0x01 : [(0x02, 0x02, []),
+                                                 (0x12, 0x1A, [0x16]),
+                                                 (0x26, 0x42, [0x2A])],
+                                         0x02 : [(0x06, 0x3E, [0x07, 0x30]),
+                                                 (0X50, 0x55, []),
+                                                 (0x5C, 0x61, []),
+                                                 (0x6B, 0x72, []),
+                                                 (0x8A, 0x99, [0x92, 0x93, 0x95, 0x98]),
+                                                 (0x9D, 0x9F, []),
+                                                 (0xA9, 0xAB, []),
+                                                 (0xB7, 0xB7, [])],
+                                         0x03 : [(0x02, 0x2D, []),
+                                                 (0x38, 0x52, [0x3A]),
+                                                 (0x59, 0x60, [])],
+                                         0x04 : [(0x87, 0x87, [])],
+                                         0x05 : [(0x08, 0x21, [0x14, 0x20]),
+                                                 (0x2A, 0x3E, [0x30, 0x3A, 0x3B, 0x3C]),
+                                                 (0x89, 0x8A, []),
+                                                 (0x9B, 0xA6, [0x9C, 0xA3, 0xA4, 0xA5])],
+                                         0x08 : [(0x02, 0x61, [])],
+                                         0x09 : [(0x0E, 0x0E, []),
+                                                 (0x43, 0x43, []),
+                                                 (0x49, 0x4A, []),
+                                                 (0x4E, 0x4F, []),
+                                                 (0x5E, 0x5E, [])],
+                                         0x0A : [(0x02, 0x05, []),
+                                                 (0x14, 0x14, []),
+                                                 (0x1A, 0x1A, []),
+                                                 (0x20, 0x20, []),
+                                                 (0x26, 0x26, [])],
+                                         0x0B : [(0x44, 0x4A, [0x45, 0x49]),
+                                                 (0x57, 0x58, [])]
+                                         }
+
+        def __init__(self):
+            self.current_page_index = 0
+            self.current_page = self._regmap_pages[self.current_page_index]
+            self.current_range_index = 0
+            minreg, maxrex, excl = self._regmap_pages_register_ranges[self.current_page][self.current_range_index]
+            self.current_register = minreg
+            pass
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return self.next()
+
+        def next(self):
+            current_range = self._regmap_pages_register_ranges[self.current_page][self.current_range_index]
+            current_min, current_max, current_excluded = current_range
+
+            if self.current_register == current_max:    # Move to next range in page, and next page if last range
+                self.current_range_index += 1
+                if self.current_range_index >= len(self._regmap_pages_register_ranges[self.current_page]):
+                    # Move to next page at range 0
+                    self.current_page_index += 1
+                    if self.current_page_index >= len(self._regmap_pages):      # Last page finished
+                        raise StopIteration()
+                    self.current_page = self._regmap_pages[self.current_page_index]
+                    self.current_range_index = 0
+
+                minreg, maxrex, excl = self._regmap_pages_register_ranges[self.current_page][self.current_range_index]
+                self.current_register = minreg          # Get first register in range
+                return self.current_page, self.current_register
+
+            elif self.current_register in current_excluded:     # Read onwards until a non-excluded register reached
+                self.current_register += 1
+                return self.next()
+
+            else:                                       # Read next value normally
+                self.current_register += 1
+                return self.current_page, self.current_register
+
+
+    # An iterable of tuples in the form (page, register) where the pages and registers are those
+    # that should be read from the device when creating a settings map with export_register_map()
+    # for later re-write with the import_register_map() function.
+    _regmap_pages_registers_iter = regmap_generator()
 
     # The register maps to be written to the device require a preamble and postamble that write
     # registers that place the device into an acceptable start state.
@@ -278,6 +327,7 @@ class _SI534x:
         #TODO if ICAL (or another finishing command) is actually still relevant
 
     def export_register_map(self, mapfile_location):
+        #TODO update this text
         """
         Generate a register map file using the current settings in device control
         registers. This file can then be loaded using apply_register_map(filename).
@@ -285,19 +335,23 @@ class _SI534x:
         :param mapfile_location: location of register map file that will be written to.
         """
         with open(mapfile_csv_location, 'w') as csv_file:
+            #TODO Potentially update header line wiht more information
             csv_file.write("# This register map has been generated for the odin-devices SI5324 driver.\n")
             csv_writer = csv.writer(csv_file, delimiter=',')
 
             # The registers that will be read are the ones found in output register
             # maps from DSPLLsim.
-            for page_register in SI534x._regmap_registers:
+            for page, register in SI534x._regmap_pages_registers_iter:
 
                 #TODO potentially include any registers that read as 0 for triggers, that should not be
                 # included in a write map, or need their values changing (like SI5342 ICAL)
 
                 value = self._read_registers(page, register)
-                logger.info("Read register {}: {:02X}".format(register, value))
-                f.write("{}, {:02X}h\n".format(register, value))
+                logger.info("Read register 0x{:02X}{:02X}: {:02X}".format(page, register, value))
+
+                # File target format combines page and register into one 4-nibble hex value
+                page_reg_combined = "0x{:02X}{:02X}".format(page, register)
+                csv_writer.writerow([page_reg_combined, value])
 
             logger.info("Register map extraction complete, to file: {}".format(mapfile_location))
 

--- a/src/odin_devices/si534x.py
+++ b/src/odin_devices/si534x.py
@@ -102,7 +102,7 @@ class _SI534x(object):
 
         def write(self, data, channel_num):
             # Check channel number is valid
-            if channel_num >= self.num_channels:
+            if channel_num >= self.channel_num:
                 raise SI534xException(
                         "The channel number specified does not exist.")
 
@@ -116,7 +116,7 @@ class _SI534x(object):
 
         def read(self, channel_num):
             # Check channel number is valid
-            if channel_num >= self.num_channels:
+            if channel_num >= self.channel_num:
                 raise SI534xException(
                         "The channel number specified does not exist.")
 

--- a/src/odin_devices/si534x.py
+++ b/src/odin_devices/si534x.py
@@ -391,7 +391,7 @@ class _SI534x(object):
     def _write_register_i2c(self, register, value):
         # Wrapper for writing a full 8-bit register over I2C, without page logic.
         # print("Writing to register ", register, " with value ", value, " using I2C")
-        self.i2c_bus.writeU8(register, value)
+        self.i2c_bus.write8(register, value)
 
     def _read_register_i2c(self, register):
         # Wrapper for reading a full 8-bit register over I2C, without page logic.
@@ -514,10 +514,11 @@ class _SI534x(object):
             for row in csv_reader:
                 # The register map starts after general information is printed preceded by '#'
                 print("Line read from CSV: ", row) #TODO remove or make a logging line
-                if row[0][0] != '#':
+                if row[0][0] == '0':    # Register values are preceeded by 0x
                     # Extract register-value pairing from register map
                     page_register = int(row[0], 0)  # 0x prefix detected automatically
-                    value = int(row[1][:-2], 0)     # \\r removed
+                    #value = int(row[1][:-2], 0)     # \\r removed
+                    value = int(row[1], 0)
                     register = page_register & 0xFF         # Lower byte
                     page = (page_register & 0xFF00) >> 8    # Upper byte
                     print("Storing value ", value, " in register ", register, " of page ", page)#TODO remove
@@ -582,7 +583,7 @@ class SI5345 (_SI534x):
 class SI5344 (_SI534x):
     def __init__(self, i2c_address=None, spi_device=None,
                  LOS_Line=None, LOL_Line=None, INT_Line=None):
-        super(SI5345, self).__init__([2, 3, 6, 7],  # 4 Channels, in SI5345 map positons 2, 3, 6, 7
+        super(SI5344, self).__init__([2, 3, 6, 7],  # 4 Channels, in SI5345 map positons 2, 3, 6, 7
                                      4,             # 4 Multisynths, 1 per channel
                                      i2c_address, spi_device,
                                      LOS_Line, LOL_Line, INT_Line)
@@ -591,7 +592,7 @@ class SI5344 (_SI534x):
 class SI5342 (_SI534x):
     def __init__(self, i2c_address=None, spi_device=None,
                  LOS_Line=None, LOL_Line=None, INT_Line=None):
-        super(SI5345, self).__init__([2, 3],        # 2 Channels, in SI5345 map positions 2, 3
+        super(SI5342, self).__init__([2, 3],        # 2 Channels, in SI5345 map positions 2, 3
                                      2,             # 2 Multisynths, 1 per channel
                                      i2c_address, spi_device,
                                      LOS_Line, LOL_Line, INT_Line)

--- a/src/odin_devices/si534x.py
+++ b/src/odin_devices/si534x.py
@@ -272,6 +272,12 @@ class _SI534x(object):
                                                                    start_register = 0x02,
                                                                    start_bit_pos = 0, bit_width = 1,
                                                                    parent_device = self)
+        self._hard_reset_bit = _SI534x._BitField(page=0x00, start_register = 0x01E,
+                                                 start_bit_pos = 1, bit_width = 1,
+                                                 parent_device = self)
+        self._soft_reset_bit = _SI534x._BitField(page=0x00, start_register = 0x01C,
+                                                 start_bit_pos = 2, bit_width = 1,
+                                                 parent_device = self)
 
         #TODO define channel-mapped fields
         self._output_driver_cfg_PDN = _SI534x._Channel_BitField(page=0x01,
@@ -378,6 +384,15 @@ class _SI534x(object):
         pass
 
     #TODO add functions for desirable option changes
+
+    def reset(self, soft=False):
+        if soft:    # Reset state machines
+            self._soft_reset_bit.write(1)
+            self._soft_reset_bit.write(0)
+        else:       # POR device. Registers set to default.
+            self._hard_reset_bit.write(1)
+            self._hard_reset_but.write(0)
+
 
 
     """

--- a/tests/test_gpio_bus.py
+++ b/tests/test_gpio_bus.py
@@ -1,0 +1,414 @@
+
+import sys
+import pytest
+
+if sys.version_info[0] == 3:    # pragma: no cover
+    from unittest.mock import Mock, mock_open, MagicMock, patch
+    from importlib import reload
+else:                           # pragma: no cover
+    from mock import Mock, mock_open, MagicMock, patch
+    ModuleNotFoundError = ImportError
+
+# Create mocks
+sys.modules['gpiod'] = Mock()
+sys.modules['logging'] = Mock() # Track calls to logger.warning
+
+#import odin_devices.gpio_bus        # Needs direct import so module can be reloaded live
+from odin_devices.gpio_bus import GPIO_Bus, GPIO_ZynqMP, logger, GPIOException, _ASYNC_AVAIL
+
+class gpio_bus_test_fixture(object):
+
+    def __init__(self):
+        # Instantiate a basic 10-line bus with GPIO chip '1' and offset '20'
+        #self.gpio_bus_basic = GPIO_Bus(10, 1, 20);  # Instantiate a basic GPIO BUS
+        pass
+
+@pytest.fixture(scope="class")
+def test_gpio_bus():
+    test_driver_fixture = gpio_bus_test_fixture()
+    yield test_driver_fixture
+
+def raise_OSError():
+    raise OSError
+
+class TestGPIOBus():
+
+    def test_imports_noconcurrent(self, test_gpio_bus):
+        # remove concurrent reference so that on import it will fail
+        if sys.version_info[0] == 3:    #pragma: no cover
+            import concurrent
+            oldconcurrent = sys.modules['concurrent']
+            sys.modules['concurrent'] = None
+        else:                           #pragma: no cover
+            import futures
+            oldfutures = sys.modules['futures']
+            sys.modules['futures'] = None
+
+        # import with concurrent removed
+        import odin_devices.gpio_bus
+        reload(odin_devices.gpio_bus)
+        from odin_devices.gpio_bus import GPIO_Bus, GPIOException
+
+        # Init a test bus
+        test_gpio_bus.gpio_bus_temp = GPIO_Bus(5, 1, 20)    # Test same request as before
+        test_gpio_bus.gpio_bus_temp._master_linebulk = MagicMock()  # Make sure these calls do nothing
+        test_gpio_bus.gpio_bus_temp._check_pin_avail = MagicMock()  # Make sure tests don't to verify pins
+
+        # Attempt the use of a synchronous event call (gpiod mocked), should not throw error
+        test_gpio_bus.gpio_bus_temp.register_pin_event(1, GPIO_Bus.EV_REQ_RISING)
+
+        # Attempt the use of an asynchronous event call, expecting an error thrown
+        with pytest.raises(GPIOException, match=".*Asynchronous operations not available.*"):
+            try:
+                test_gpio_bus.gpio_bus_temp.register_pin_event_callback(2, GPIO_Bus.EV_REQ_RISING, None)
+            except ModuleNotFoundError:
+                pass    # Stop trigger error causing failure if it is not handled
+
+        # Free any claimed pins
+        test_gpio_bus.gpio_bus_temp.release_all_consumed()
+
+        # Restore concurrent
+        if sys.version_info[0] == 3:    #pragma: no cover
+            sys.modules['concurrent'] = oldconcurrent
+        else:                           #pragma: no cover
+            sys.modules['futures'] = oldfutures
+        import odin_devices.gpio_bus
+        reload(odin_devices.gpio_bus)
+        from odin_devices.gpio_bus import GPIO_Bus, GPIOException
+
+        # Check async was restored (stops later async test failing)
+        from odin_devices.gpio_bus import _ASYNC_AVAIL
+        assert(_ASYNC_AVAIL)
+
+    def test_instantiation_chip(self, test_gpio_bus):
+        from odin_devices.gpio_bus import GPIO_Bus, GPIOException
+
+        # Create temporary test bus
+        test_gpio_bus.gpio_bus_temp = GPIO_Bus(5, 1, 20)
+
+        # Test initial chipname chosen is correct for basic GPIO instance
+        #test_gpio_bus.gpio_bus_temp.gpiod.Chip = MagicMock(return=
+        sys.modules['gpiod'].Chip.assert_called_with("/dev/gpiochip1")
+
+        # Test the correct line numbers are requested with offset
+        assert (list(test_gpio_bus.gpio_bus_temp._gpio_chip.get_lines.call_args[0][0]) == [20,21,22,23,24])
+
+        # Test offset correctly stored
+        assert test_gpio_bus.gpio_bus_temp._width == 5
+
+    def test_invalid_gpio_chip(self, test_gpio_bus):
+        from odin_devices.gpio_bus import GPIO_Bus, GPIOException
+        # Test the driver's reaction to an FileNotFoundError thrown on call to gpiod.Chip()
+
+        # Set the side-effect of calling gpiod.Chip() as FileNotFoundError
+        sys.modules['gpiod'].Chip.side_effect = FileNotFoundError
+
+        # Check that the FileNotFoundError triggers a GPIOError which warns about gpiochip
+        with pytest.raises(GPIOException, match=".*gpiochip.*"):
+            try:
+                test.gpio_bus.gpio_bus_temp = GPIO_Bus(5, 1, 20)    # Test same request as before
+            except FileNotFoundError:
+                pass    # Stop trigger error causing failure if it is not handled
+
+        # Remove the error side-effect
+        sys.modules['gpiod'].Chip.side_effect = None
+
+    def test_invalid_line_range(self, test_gpio_bus):
+        from odin_devices.gpio_bus import GPIO_Bus, GPIOException
+        # Test instantiation with invalid linebulk ranges (pins not available on the gpiochip)
+        # In this case, gpiod throws an OSError
+
+        # Use patch to patch Chip class' instance
+        with patch('gpiod.Chip') as MockChip:
+            # Make sure 'valid' chip instance will fail on call of get_lines
+            instance = MockChip.return_value
+            instance.get_lines.side_effect = OSError
+
+            with pytest.raises(GPIOException, match=".*out of range.*"):
+                try:
+                    test_g = GPIO_Bus(5, 1, 20)
+                except OSError:
+                    print("An OSError was triggered. Should have been caught by gpio_bus")
+                    pass
+
+    def test_consumer_naming(self, test_gpio_bus):
+        from odin_devices.gpio_bus import GPIO_Bus, GPIOException
+        # Test that when the consumer name is changed, the correct name is used to claim lines
+        # inside the calls to gpiod.
+
+        # Init a test bus of width 5
+        test_gpio_bus.gpio_bus_temp = GPIO_Bus(5, 0, 0)
+
+        # Mock the linebulk so that it returns a free Line object mock
+        mockline = sys.modules['gpiod'].Line()
+        mockline.is_requested.return_value = False
+        mockline.is_used.return_value = False
+        test_gpio_bus.gpio_bus_temp._master_linebulk.to_list.return_value = [mockline]
+
+        # Set a non-default consumer name
+        default_consumer_name = test_gpio_bus.gpio_bus_temp.get_consumer_name()
+        test_gpio_bus.gpio_bus_temp.set_consumer_name("nonstandard_consumername")
+
+        # Check sure we have actually set using a new name
+        assert test_gpio_bus.gpio_bus_temp.get_consumer_name() != default_consumer_name
+
+        # Check sure the new consumer name is sent to gpiod
+        test_gpio_bus.gpio_bus_temp.get_pin(0, GPIO_Bus.DIR_INPUT, False, False)
+        mockline.request.assert_called_with(consumer="nonstandard_consumername",
+                type=GPIO_Bus.DIR_INPUT,
+                default_val=0,flags=0)
+
+    def test_width_setting(self, test_gpio_bus):
+        from odin_devices.gpio_bus import GPIO_Bus, GPIOException
+        # Test that the width changes correctly, and properly frees any lines that would become
+        # unusable in the event of a reduced width. Also checks invalid widths.
+
+        # Init a test bus of width 5 with no offset
+        test_gpio_bus.gpio_bus_temp = GPIO_Bus(5, 0, 0)
+
+        # Check the width has been correctly set as 5
+        assert test_gpio_bus.gpio_bus_temp._width == 5
+
+        # Set gpiod get_lines to return a list of 10 lines (for checking this becomes the linebulk)
+        mockline_list = [sys.modules['gpiod'].Line()] * 10
+        mocklines = Mock()
+        mocklines.to_list.return_value = mockline_list
+        test_gpio_bus.gpio_bus_temp._gpio_chip.get_lines.return_value = mocklines
+
+        # Increase width to 10
+        test_gpio_bus.gpio_bus_temp.set_width(10)
+
+        # Check that gpiod get_lines called with correct range, width is 10 and assignment is made
+        test_gpio_bus.gpio_bus_temp._gpio_chip.get_lines.assert_called_with(range(0, 10))
+        assert test_gpio_bus.gpio_bus_temp._width == 10
+        assert test_gpio_bus.gpio_bus_temp._master_linebulk == mocklines
+        assert(test_gpio_bus.gpio_bus_temp.get_width() == 10)
+
+        # Check that reducing bus width causes pins to be freed
+        test_gpio_bus.gpio_bus_temp.set_width(5)
+        for mockline_num in range(5, 10):
+            mocklines.to_list()[mockline_num].release.assert_called()
+
+        # Check that creating a bus with a range less than 1 results in error
+        with pytest.raises(GPIOException, match=".*Width supplied is invalid.*"):
+            GPIO_Bus(0, 0, 0)
+        with pytest.raises(GPIOException, match=".*Width supplied is invalid.*"):
+            GPIO_Bus(-1, 0, 0)
+
+    def test_check_pin_avail(self, test_gpio_bus):
+        from odin_devices.gpio_bus import GPIO_Bus, GPIOException
+        # Test that expected errors for pin availability trigger exceptions, and that the flag
+        # ignore_concurrent works properly.
+
+        # Init a test bus of width 1 with no offset
+        test_gpio_bus.gpio_bus_temp = GPIO_Bus(1, 0, 0)
+
+        # Create a mock line and the master linebulk
+        mockline = sys.modules['gpiod'].Line()
+        test_gpio_bus.gpio_bus_temp._master_linebulk = sys.modules['gpiod'].LineBulk()
+        test_gpio_bus.gpio_bus_temp._master_linebulk.to_list.return_value = [mockline]
+
+        # Check a pin with range beyond or before the master linebulk is rejected
+        with pytest.raises(GPIOException, match=".*out of range, bus width: 1.*"):
+            test_gpio_bus.gpio_bus_temp._check_pin_avail(6)
+        with pytest.raises(GPIOException, match=".*index cannot be negative.*"):
+            test_gpio_bus.gpio_bus_temp._check_pin_avail(-1)
+
+        # Check a pin that returns is_used() will be rejected
+        mockline.is_used.return_value = True
+        mockline.is_requested.return_value = False
+        test_gpio_bus.gpio_bus_temp._master_linebulk.to_list.return_value = [mockline]
+        with pytest.raises(GPIOException, match=".*in use by another user.*"):
+            test_gpio_bus.gpio_bus_temp._check_pin_avail(0)
+
+        # Check a pin that returns is_requested will be rejected, but only if not passed the
+        # ignore_current argument.
+        mockline.is_used.return_value = False
+        mockline.is_requested.return_value = True
+        test_gpio_bus.gpio_bus_temp._master_linebulk.to_list.return_value = [mockline]
+        with pytest.raises(GPIOException, match=".*already requested ownership.*"):
+            test_gpio_bus.gpio_bus_temp._check_pin_avail(0)
+        test_gpio_bus.gpio_bus_temp._check_pin_avail(0, ignore_current=True) # Should not throw
+
+
+    def test_get_pin(self, test_gpio_bus):
+        from odin_devices.gpio_bus import GPIO_Bus, GPIOException
+        # Test that get_pin calls the expected checks and forwards correct values to to gpiod
+        # when making the line request.
+
+        # Create a new GPIO bus and a mocked line
+        test_gpio_bus.gpio_bus_temp = GPIO_Bus(1, 0, 0)
+        test_gpio_bus.gpio_bus_temp._master_linebulk = sys.modules['gpiod'].LineBulk()
+        mockline = sys.modules['gpiod'].Line()
+
+        # Change the consumer name for later checks
+        test_gpio_bus.gpio_bus_temp.set_consumer_name("test_get_pin")
+
+        # Check that _check_pin_avail is called and will trigger an exception (see full test above)
+        with pytest.raises(GPIOException, match=".*out of range, bus width: 1.*"):
+            test_gpio_bus.gpio_bus_temp.get_pin(2, GPIO_Bus.DIR_OUTPUT)
+
+        # Check that calling on an already requested pin with no_request supplies the line without
+        # calling the gpiod line request
+        mockline.is_requested.return_value = True
+        mockline.is_used.return_value = False
+        mockline.request.reset_mock()                   # Reset call count
+        test_gpio_bus.gpio_bus_temp._master_linebulk.to_list.return_value = [mockline]
+        pinout = test_gpio_bus.gpio_bus_temp.get_pin(0, GPIO_Bus.DIR_OUTPUT, no_request=True)
+        assert(pinout == mockline)                      # Check line is returned correctly
+        print(test_gpio_bus.gpio_bus_temp._master_linebulk.to_list()[0].request.mock_calls)
+        test_gpio_bus.gpio_bus_temp._master_linebulk.to_list()[0].request.assert_not_called()
+
+        # Check that calling with no_request on a line ID that does not exist still causes an error
+        with pytest.raises(GPIOException, match=".*out of range.*"):
+            pinout = test_gpio_bus.gpio_bus_temp.get_pin(2, GPIO_Bus.DIR_OUTPUT, no_request=True)
+
+        # Check that a line request with different active_l and direction translate to correct
+        # values being propagated to gpiod, and that the consumer name is correct.
+        test_gpio_bus.gpio_bus_temp._master_linebulk.to_list()[0].is_requested.return_value = False
+        test_gpio_bus.gpio_bus_temp._master_linebulk.to_list()[0].is_used.return_value = False
+
+        mockline.request.reset_mock()                   # Reset call count
+        test_gpio_bus.gpio_bus_temp.get_pin(0, GPIO_Bus.DIR_OUTPUT, active_l = False)
+        test_gpio_bus.gpio_bus_temp._master_linebulk.to_list()[0].request.assert_called_with(
+                consumer="test_get_pin",
+                type=sys.modules['gpiod'].LINE_REQ_DIR_OUT,
+                flags=0,                        # NOTE: assumes no flags other than active low
+                default_val=0)
+
+        mockline.request.reset_mock()                   # Reset call count
+        test_gpio_bus.gpio_bus_temp.get_pin(0, GPIO_Bus.DIR_OUTPUT, active_l = True)
+        test_gpio_bus.gpio_bus_temp._master_linebulk.to_list()[0].request.assert_called_with(
+                consumer="test_get_pin",
+                type=sys.modules['gpiod'].LINE_REQ_DIR_OUT,
+                flags=sys.modules['gpiod'].LINE_REQ_FLAG_ACTIVE_LOW,
+                default_val=0)
+
+        mockline.request.reset_mock()                   # Reset call count
+        test_gpio_bus.gpio_bus_temp.get_pin(0, GPIO_Bus.DIR_INPUT, active_l = False)
+        test_gpio_bus.gpio_bus_temp._master_linebulk.to_list()[0].request.assert_called_with(
+                consumer="test_get_pin",
+                type=sys.modules['gpiod'].LINE_REQ_DIR_IN,
+                flags=0,                        # NOTE: assumes no flags other than active low
+                default_val=0)
+
+    def test_get_bulk_pins(self, test_gpio_bus):
+        from odin_devices.gpio_bus import GPIO_Bus, GPIOException
+        # This method will be using the same logic as the get_pin(), one so these tests will focus
+        # on differences between the two.
+
+        # Create a test mock linebulk with all pre-requested lines
+        mockline = sys.modules['gpiod'].Line()
+        mockline.is_requested.return_value = True
+        mockline.is_used.return_value = False
+        mocklines = [mockline, mockline, mockline]
+        mocklinebulk = sys.modules['gpiod'].LineBulk()
+        mocklinebulk.to_list.return_values = mocklines
+        test_gpio_bus.gpio_bus_temp._master_linebulk.to_list.return_value = mocklines
+        test_gpio_bus.gpio_bus_temp._master_linebulk.get_lines.return_value = mocklinebulk
+
+        # Create a new GPIO bus with the new mocklines
+        test_gpio_bus.gpio_bus_temp = GPIO_Bus(3, 0, 0)
+        test_gpio_bus.gpio_bus_temp._master_linebulk = sys.modules['gpiod'].LineBulk()
+
+        # Check that if one of the lines is requested, an exception will be raised
+        with pytest.raises(GPIOException, match=""):
+            test_gpio_bus.gpio_bus_temp.get_bulk_pins([0,1,2], GPIO_Bus.DIR_OUTPUT)
+
+    def test_synchronous_events(self, test_gpio_bus):
+        from odin_devices.gpio_bus import GPIO_Bus, GPIOException
+
+        # Create a single line bus for testing (unused and unrequested)
+        test_gpio_bus.gpio_bus_temp = GPIO_Bus(1, 0, 0)
+        test_gpio_bus.gpio_bus_temp.set_consumer_name("test_sync_events")
+        mockline = sys.modules['gpiod'].Line()
+        mockline.is_requested.return_value = False
+        mockline.is_used.return_value = False
+        mockline.request.reset_mock()                   # Reset call count
+        test_gpio_bus.gpio_bus_temp._master_linebulk = sys.modules['gpiod'].LineBulk()
+        test_gpio_bus.gpio_bus_temp._master_linebulk.to_list.return_value = [mockline]
+
+        # Check event requests send expected request to gpiod
+        test_gpio_bus.gpio_bus_temp.register_pin_event(0, GPIO_Bus.EV_REQ_FALLING)
+        mockline.request.assert_called_with(
+                consumer="test_sync_events",
+                type=sys.modules['gpiod'].LINE_REQ_EV_FALLING_EDGE)
+
+        # Check that only valid events are accepted
+        with pytest.raises(GPIOException, match=".*Invalid event type.*"):
+            test_gpio_bus.gpio_bus_temp.register_pin_event(0, 1010)
+
+        # Check that the wait pin event with a timeout and returns False with no event found
+        mockline.is_requested.return_value = True       # Make sure line is not rejected
+        mockline.event_wait.return_value = False        # Return timeout respose
+        assert(test_gpio_bus.gpio_bus_temp.wait_pin_event(0, 10) == False)  # Timeout is instant
+
+        # Check that the wait pin event exits on manual event trigger and reports correct event
+        mockline.is_requested.return_value = True
+        mockline.event_wait.return_value = True
+        mockline.event_read.return_value = sys.modules['gpiod'].LineEvent.RISING_EDGE
+        assert(test_gpio_bus.gpio_bus_temp.wait_pin_event(0, 10) == GPIO_Bus.EVENT_RISING)
+
+        # Check that user is prevented from waiting on a non-requested line
+        mockline.is_requested.return_value = False
+        with pytest.raises(GPIOException):
+            test_gpio_bus.gpio_bus_temp.wait_pin_event(0, 10)
+
+
+    def test_asynchronous_events(self, test_gpio_bus):
+        from odin_devices.gpio_bus import GPIO_Bus, GPIOException, _ASYNC_AVAIL
+
+        # Create a single line bus for testing (unused and unrequested)
+        test_gpio_bus.gpio_bus_temp = GPIO_Bus(2, 0, 0)
+        test_gpio_bus.gpio_bus_temp.set_consumer_name("test_sync_events")
+        #mockline = sys.modules['gpiod'].Line()
+        mockline1 = Mock()
+        mockline2 = Mock()
+        mockline1.is_requested.return_value = False
+        mockline1.is_used.return_value = False
+        mockline2.is_requested.return_value = False
+        mockline2.is_used.return_value = False
+        test_gpio_bus.gpio_bus_temp._master_linebulk = sys.modules['gpiod'].LineBulk()
+        test_gpio_bus.gpio_bus_temp._master_linebulk.to_list.return_value = [mockline1, mockline2]
+
+        # Check that only valid events are accepted
+        with pytest.raises(GPIOException, match=".*Invalid event type.*"):
+            test_gpio_bus.gpio_bus_temp.register_pin_event_callback(0, 1010, int)
+
+        # Check that two separate callbacks can be created and triggered independently
+        callback_function_1 = Mock()    # Create mocked callback functions
+        callback_function_2 = Mock()
+        mockline1.event_read.return_value = GPIO_Bus.EVENT_FALLING      # Set event type
+        mockline2.event_read.return_value = GPIO_Bus.EVENT_RISING       # Set event type
+        mockline1.event_wait.return_value = False       # Set events to keep waiting for now
+        mockline2.event_wait.return_value = False
+        test_gpio_bus.gpio_bus_temp.register_pin_event_callback(0,  # Start monitor thread pin0
+                GPIO_Bus.EV_REQ_FALLING, callback_function_1)
+        test_gpio_bus.gpio_bus_temp.register_pin_event_callback(1,  # Start monitor thread pin1
+                GPIO_Bus.EV_REQ_RISING, callback_function_2)
+        callback_function_1.assert_not_called()         # Make sure callback not called yet
+        callback_function_2.assert_not_called()         # Make sure callback not called yet
+        mockline1.event_wait.return_value = True        # TRIGGER pin1 event
+        mockline2.event_wait.return_value = True        # TRIGGER pin2 event
+        print(callback_function_2)
+        test_gpio_bus.gpio_bus_temp.remove_pin_event_callback(0)
+        test_gpio_bus.gpio_bus_temp.remove_pin_event_callback(1)
+
+        callback_function_1.assert_called()        # Make sure callback called after event
+        callback_function_2.assert_called()        # Make sure callback called after event
+        # Note: number of calls not checked, because real gpiod would only return true once
+
+        # Note: checking events do not trigger on the incorrect event_read() return value is not
+        #       necessary, as gpiod will not return true to event_wait() if event is wrong type.
+
+        # Check that monitors can be terminated before an event
+        mockline1.event_wait.return_value = False                   # Set event to wait for now
+        callback_function_1.reset_mock()                            # Reset callback count
+        test_gpio_bus.gpio_bus_temp.register_pin_event_callback(0,  # Monitor for falling event
+                GPIO_Bus.EV_REQ_FALLING, callback_function_1)
+        # (No event triggered)
+        test_gpio_bus.gpio_bus_temp.remove_pin_event_callback(0)    # Remove callback
+        callback_function_1.assert_not_called()                     # Check event not called
+        mockline1.event_wait.return_value = True                    # Trigger falling event
+        callback_function_1.assert_not_called()                     # Check event not called
+

--- a/tests/test_si534x.py
+++ b/tests/test_si534x.py
@@ -1,0 +1,133 @@
+import sys
+import pytest
+
+if sys.version_info[0] == 3:    # pragma: no cover
+    from unittest.mock import Mock, mock_open, patch
+    BUILTINS_NAME = 'builtins'
+else:                           # pramga: no cover
+    from mock import Mock, mock_open, patch
+    BUILTINS_NAME = '__builtin__'
+
+sys.modules['smbus'] = Mock()
+sys.modules['logging'] = Mock() # Track calls to logger.warning
+from odin_devices.si534x import _SI534x, SI5344, SI5345, SI5342, SI534xCommsException
+from odin_devices.i2c_device import I2CException
+
+class si534xTestFixture(object):
+
+    def __init__(self):
+        self.si5345_i2c = SI5345(i2c_address = 0xAA)
+        self.virtual_registers = {}
+        self.virtual_page_select = 0x00
+        self.si5345_i2c.i2c_bus = Mock()
+
+    def virtual_registers_en(self, en):
+        if en:
+            print("I2C interface now driving virtual register map")
+            self.si5345_i2c.i2c_bus.writeU8.side_effect = self.write_virtual_regmap
+            self.si5345_i2c.i2c_bus.readU8.side_effect = self.read_virtual_regmap
+        else:
+            print("I2C interface now has no effect")
+
+    def read_virtual_regmap(self, register):
+        if register == 0x01:
+            # This is the page select register
+            print("REGISTER MOCK: Page select requested: ", self.virtual_page_select)
+            return self.virtual_page_select
+        else:
+            print("REGISTER MOCK: Register {} value requested: {}".format(register,
+                self.virtual_registers[self.virtual_page_select][register]))
+            return self.virtual_registers[self.virtual_page_select][register]
+
+    def write_virtual_regmap(self, register, value):
+        if register == 0x01:
+            # This is the page select register
+            print("REGISTER MOCK: Page select changed: ", value)
+            self.virtual_page_select = value
+        else:
+            print("REGISTER MOCK: Register {} changed: {}".format(register, value))
+            self.virtual_registers[self.virtual_page_select][register] = value
+
+@pytest.fixture(scope="class")
+def test_si534x_driver():
+    test_driver_fixture = si534xTestFixture()
+    yield test_driver_fixture
+
+class TestSI534x():
+
+    def test_i2c_init(self, test_si534x_driver):
+        pass
+
+    def test_spi_init(self, test_si534x_driver):
+        pass
+
+    def test_standard_field_rw(self, test_si534x_driver):
+        pass
+
+    def test_channelmap_register_addressing(self, test_si534x_driver):
+        pass
+
+    def test_multisynthmap_register_addressing(self, test_si534x_driver):
+        pass
+
+    def test_regmap_file_rw(self, test_si534x_driver):
+        test_si534x_driver.virtual_registers_en(True)
+
+        # For a reproducible pattern, set registers to equal the bitwise OR of page and reg num.
+        test_si534x_driver.virtual_registers = {}
+        regmap_generator = _SI534x._regmap_generator()
+        for page, register in regmap_generator:       # Make sure this is up to date
+            if not page in test_si534x_driver.virtual_registers.keys():
+                test_si534x_driver.virtual_registers[page] = {}
+            test_si534x_driver.virtual_registers[page][register] = page | register
+            #print("setting page ", page, " register ", register, " to ", page|register)
+
+        # Mock export to imaginary file
+        mock_file_open = mock_open()
+        with patch(BUILTINS_NAME + '.open', mock_file_open):
+            # Write temporary memory-based file
+            test_si534x_driver.si5345_i2c.export_register_map('nofile.txt')
+            mock_file_open.assert_called()
+
+        # Assemble 'file' to feed back in with the written lines captured
+        tmp_file_str = ""
+        for writeline in mock_file_open.mock_calls:
+            if not "call().write" in str(writeline):
+                continue
+            tmp_file_str += str(writeline)[14:-4] + "\n"
+            print(writeline)
+        print(tmp_file_str)
+
+        # Change all virtual register values to 0xFF
+        for page_no in test_si534x_driver.virtual_registers.keys():
+            page_dict = test_si534x_driver.virtual_registers[page_no]
+            for register in page_dict.keys():
+                test_si534x_driver.virtual_registers[page_no][register] = 0xFF
+
+        print(test_si534x_driver.virtual_registers)
+
+        # Write registers from 'saved' register map file (import register map)
+        mock_file_open = mock_open(read_data=tmp_file_str)
+        with patch(BUILTINS_NAME + '.open', mock_file_open):
+            test_si534x_driver.si5345_i2c.apply_register_map('nofile.txt')
+
+        # Check that reigsters have their values restored from file
+        for page_no in test_si534x_driver.virtual_registers.keys():
+            page_dict = test_si534x_driver.virtual_registers[page_no]
+            print("Checking assertions for page no {:02X}: {}".format(page_no, page_dict))
+            for register in page_dict.keys():
+                print("\tChecking assertion for register {:02X}".format(register))
+                assert(test_si534x_driver.virtual_registers[page_no][register] == page_no | register)
+
+        # Test that verify will raise exception if there is a failure
+        test_si534x_driver.si5345_i2c.i2c_bus.readU8.side_effect = [
+                0xFF,0xFF]                              # Force smbus read to always return 0xFF
+        mock_file_open = mock_open(read_data=tmp_file_str)
+        with patch(BUILTINS_NAME + '.open', mock_file_open):
+            with pytest.raises(SI534xCommsException, match=".*Write of byte to register.*"): # Check for exception
+                test_si534x_driver.si5345_i2c.apply_register_map('nofile.txt', verify=True)
+
+        test_si534x_driver.virtual_registers_en(False)  # smbus read reset
+
+
+#TODO add tests for device function functions...


### PR DESCRIPTION
Add support for SI534x family of devices. Classes have been added for SI5345, SI5344 and SI5342.

Note that this PR will require the merging of add-gpiod first, since it is used for the firefly chip selects.