### PR TITLE
Fix BME280 humidity reading

### DIFF
--- a/src/odin_devices/bme280.py
+++ b/src/odin_devices/bme280.py
@@ -158,7 +158,7 @@ class BME280(object):  # Explicit new-style class for @property with py2
         ctrl_meas sets the pressure and temperature data acquisition options.
         ctrl_hum sets the humidity oversampling and must be written to first.
         """
-        self._write_register_byte(_BME280_REGISTER_STATUS, self._overscan_humidity)
+        self._write_register_byte(_BME280_REGISTER_CTRL_HUM, self._overscan_humidity)
         self._write_register_byte(_BME280_REGISTER_CTRL_MEAS, self._ctrl_meas)
 
     def _get_status(self):


### PR DESCRIPTION
This PR addresses issue #17 , where BME280 humidty readings are incorrect (abnormally high) to due an incorrect register address used to configure the humidity overscan mode.
