### PR TITLE
Update python-package.yml to fail on failed linting with flake8

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,7 +40,7 @@ jobs:
          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      continue-on-error: true
+      continue-on-error: false
     - name: Test with pytest
       run: |
         pytest --cov=./src --cov-report xml --cov-report=html

--- a/scripts/run_max31856.py
+++ b/scripts/run_max31856.py
@@ -4,8 +4,7 @@ The temperature is fetched and printed once per second.
 
 from odin_devices.max31856 import Max31856 
 from odin_devices.max31856 import ThermocoupleType
-from time import sleep
-
+import time
 
 def main():
     """Create an instance of the max31856 class.

--- a/src/odin_devices/ad5272.py
+++ b/src/odin_devices/ad5272.py
@@ -93,7 +93,7 @@ class AD5272(I2CDevice):
         #:param pd: Target potential difference (Volts)
         #
 
-        self.__wiper_pos[wiper] = int((pd - self.__low_pd) / (self.__high_pd - self.__low_pd) * self.__wiper_pos)
+        self.__wiper_pos = int((pd - self.__low_pd) / (self.__high_pd - self.__low_pd) * self.__wiper_pos)
         self.write8(((self.__wiper_pos & 0xFF00) + 0x400)>>8, (self.__wiper_pos & 0xFF))
 
     def set_wiper(self, position):

--- a/src/odin_devices/gpio_bus.py
+++ b/src/odin_devices/gpio_bus.py
@@ -34,7 +34,7 @@ Check dependencies and environment:
 
 try:
     import gpiod
-except ModuleNotFoundException:
+except ModuleNotFoundError:
     raise GPIOException(
             "gpiod module not found. "
             "This module requires libgpiod to be compiled with python bindings enabled. "

--- a/src/odin_devices/gpio_bus.py
+++ b/src/odin_devices/gpio_bus.py
@@ -258,7 +258,7 @@ class GPIO_Bus():
                 flags = 0
             lines.request(consumer=self._consumer_name,
                          type = direction,
-                         flags = active,
+                         flags = active_l,
                          default_val = 0)
 
         return lines

--- a/tests/test_firefly.py
+++ b/tests/test_firefly.py
@@ -23,7 +23,6 @@ To Test:
 
 import sys
 import pytest
-import time
 
 if sys.version_info[0] == 3:                # pragma: no cover
     from unittest.mock import Mock, MagicMock, call, patch
@@ -67,7 +66,6 @@ TX_EXAMPLE_PN =  [ord(x) for x in list('T0414xxx0114    ')]  # https://suddendoc
 
 
 def model_I2C_readList(register, length):
-    global mock_registers_areCXP, mock_registers_CXP_PS, mock_registers_QSFP_PS
     length = int(length)
     outlist = []
     for reg in range(register, register+length):
@@ -80,7 +78,6 @@ def model_I2C_readList(register, length):
 
 
 def model_I2C_readU8(register):
-    global mock_registers_areCXP, mock_registers_CXP_PS, mock_registers_QSFP_PS
     try:
         #print("\t\tSearching for register {}".format(register))
         if register <= 127:     # Lower page
@@ -94,7 +91,7 @@ def model_I2C_readU8(register):
 
 
 def model_I2C_write8(register, value):
-    global mock_registers_areCXP, mock_registers_CXP_PS, mock_registers_QSFP_PS
+    global mock_registers_CXP_PS, mock_registers_QSFP_PS
     if register <= 127:     # Lower page
         (mock_registers_CXP if mock_registers_areCXP else mock_registers_QSFP)['lower'][register] = value
     else:                   # Upper page(s)
@@ -109,7 +106,6 @@ def model_I2C_write8(register, value):
 
 
 def model_I2C_writeList(register, values):
-    global mock_registers_areCXP, mock_registers_CXP_PS, mock_registers_QSFP_PS
     for i in range(0, len(values)):
         reg = register + i
         model_I2C_write8(reg, values[i])
@@ -119,16 +115,16 @@ def model_I2C_writeList(register, values):
 
 
 def mock_I2C_SwitchDeviceQSFP():
-    global mock_registers_areCXP, mock_registers_CXP_PS, mock_registers_QSFP_PS
+    global mock_registers_areCXP
     mock_registers_areCXP = False
 
 
 def mock_I2C_SwitchDeviceCXP():
-    global mock_registers_areCXP, mock_registers_CXP_PS, mock_registers_QSFP_PS
+    global mock_registers_areCXP
     mock_registers_areCXP = True
 
 def mock_registers_reset():
-    global mock_registers_areCXP, mock_registers_CXP_PS, mock_registers_QSFP_PS
+    global mock_registers_CXP_PS, mock_registers_QSFP_PS
     print("!!! Register Map Reset !!!")
     mock_registers_CXP['lower'] = {}
     mock_registers_QSFP['lower'] = {}

--- a/tests/test_gpio_bus.py
+++ b/tests/test_gpio_bus.py
@@ -100,7 +100,7 @@ class TestGPIOBus():
         # Check that the FileNotFoundError triggers a GPIOError which warns about gpiochip
         with pytest.raises(GPIOException, match=".*gpiochip.*"):
             try:
-                test.gpio_bus.gpio_bus_temp = GPIO_Bus(5, 1, 20)    # Test same request as before
+                test_gpio_bus.gpio_bus.gpio_bus_temp = GPIO_Bus(5, 1, 20)    # Test same request as before
             except FileNotFoundError:
                 pass    # Stop trigger error causing failure if it is not handled
 


### PR DESCRIPTION
The linter is running in the CI, but errors are being ignored (including critical ones in some drivers like undefined variables). I'm going to enable this, as well as fix the drivers before merging.